### PR TITLE
[Bug]: Allow encyclopedia entity types to return entityText as the displayText value

### DIFF
--- a/src/Memory/BotMemory.ts
+++ b/src/Memory/BotMemory.ts
@@ -94,20 +94,21 @@ export class BotMemory
             this.entityMap[entityName] = new FilledEntity({entityId: entityId});
         }
 
-        let displayText = builtinType ? Utils.PrebuiltDisplayText(builtinType, resolution) : null;
+        let displayText = builtinType ? Utils.PrebuiltDisplayText(builtinType, resolution, userText) : null;
 
+        const filledEntity = this.entityMap[entityName]
         // Check if entity buckets values
         if (isBucket)
         {
             // Add if not a duplicate
-            let value = this.entityMap[entityName].values.find(v => v.userText == userText);
-            if (!value) {
-                this.entityMap[entityName].values.push(new MemoryValue({userText: userText, displayText: displayText, builtinType: builtinType, resolution: resolution}));
+            const containsDuplicateValue = filledEntity.values.some(memoryValue => memoryValue.userText === userText);
+            if (!containsDuplicateValue) {
+                filledEntity.values.push(new MemoryValue({userText: userText, displayText: displayText, builtinType: builtinType, resolution: resolution}));
             }
         }
         else
         {
-            this.entityMap[entityName].values = [new MemoryValue({userText: userText, displayText: displayText, builtinType: builtinType, resolution: resolution})];
+            filledEntity.values = [new MemoryValue({userText: userText, displayText: displayText, builtinType: builtinType, resolution: resolution})];
         }
         await this.Set();
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -163,7 +163,11 @@ export class Utils  {
         )
     }
 
-    public static PrebuiltDisplayText(prebuiltType: string, resolution: any) : string {
+    public static PrebuiltDisplayText(prebuiltType: string, resolution: any, entityText: string) : string {
+        if (prebuiltType.startsWith('builtin.encyclopedia')) {
+            return entityText
+        }
+
         switch (prebuiltType) {
             case "builtin.datetimeV2.date":
                 let date = resolution.values[0].value;
@@ -207,7 +211,8 @@ export class Utils  {
                 return resolution.value;
             case "builtin.geography.pointOfInterest":
                 return resolution.value;
-            case "builtin.encyclopedia":	
+            case "builtin.encyclopedia":
+                return entityText
             default:
                 return null;
         }


### PR DESCRIPTION
Fixes: VSTS#889
https://dialearn.visualstudio.com/BLIS/_workitems/edit/889

There were some issues causing the MemoryTable in BLIS-UI to show blanks for the encyclopedia types:

- For some reason the `encyclopedia` entities to not have a `resolution` field so this couldn't be used to get displayText
- The builtinType string extends into an undeterministic category such as `builtin.encyclopedia.people.person` which was not caught by the switch statement in Util.ts

This updates the `PrebuiltDisplayText` util to take in entityText and return it if the type is encyclopedia