### PR TITLE
Change to use user.id as memory key

### DIFF
--- a/src/BlisMemory.ts
+++ b/src/BlisMemory.ts
@@ -2,7 +2,7 @@ import * as builder from 'botbuilder'
 import { BlisDebug} from './BlisDebug';
 import { BotMemory } from './Memory/BotMemory';
 import { BotState } from './Memory/BotState';
-import { KeyGen, BlisAppBase } from 'blis-models'
+import { BlisAppBase } from 'blis-models'
 import * as Redis from "redis";
 
 export class BlisMemory {
@@ -42,10 +42,8 @@ export class BlisMemory {
     // Generate memory key from session
     public static async InitMemory(session : builder.Session) : Promise<BlisMemory> 
     {
-        let user = session.message.address.user;
-        let userdata = { id: user.id, name: user.name };
-        let key = KeyGen.MakeKey(JSON.stringify(userdata));
-        let memory = new BlisMemory(key);
+        const user = session.message.address.user;
+        const memory = new BlisMemory(user.id);
         await memory.BotState.SetAddressAsync(session.message.address);
         return memory;
     }


### PR DESCRIPTION
This reduces the need to compute a key and just uses the given unique identifier for a user.  This also makes they key independent of the user's password since we would never know the user's password.

The UI was manually assigning a user key field and sending this in requests so it could update the correct bot state or memory.

The web chat session only takes in a user id and user name and didn't allow sending the key so the id and name were re-used in the sdk to recreate the key in order to access the intended bot memory. These two can be come out of sync which causes problems.

With this change it is always set in one spot.  Whatever the UI sets the user.id to in the reducer.