### PR TITLE
Fix CORS by switching to restify-cors-middleware instead of Restify.CORS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,16 @@
         "@types/node": "7.0.39"
       }
     },
+    "@types/restify-cors-middleware": {
+      "version": "1.0.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/@types/restify-cors-middleware/-/restify-cors-middleware-1.0.1.tgz",
+      "integrity": "sha512-+S/FClLh8Wnw970RYEJ2OmdZDFwOR2GCf2hGqaB+fLdX3pRFb7WYJJHh6jN7Lrw2GiZ6LfybwgANExEC64x+Cg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.39",
+        "@types/restify": "4.3.5"
+      }
+    },
     "@types/xmldom": {
       "version": "0.1.29",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/@types/xmldom/-/xmldom-0.1.29.tgz",
@@ -138,13 +148,28 @@
       "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+      "version": "1.0.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "version": "1.5.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2.3"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "optional": true
     },
     "base64url": {
       "version": "2.0.0",
@@ -198,7 +223,7 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/botbuilder/-/botbuilder-3.9.0.tgz",
       "integrity": "sha1-NjymuWXWA6hzFvsV5SsfyKOfQMs=",
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "async": "1.5.2",
         "base64url": "2.0.0",
         "chrono-node": "1.3.5",
         "jsonwebtoken": "7.4.1",
@@ -206,7 +231,7 @@
         "request": "2.83.0",
         "rsa-pem-from-mod-exp": "0.8.4",
         "sprintf-js": "1.1.1",
-        "url-join": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz"
+        "url-join": "1.1.0"
       }
     },
     "boxen": {
@@ -261,10 +286,31 @@
         }
       }
     },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "optional": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "0.8.5",
+        "moment": "2.20.1",
+        "mv": "2.1.1",
+        "safe-json-stringify": "1.0.4"
+      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -288,7 +334,7 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/chrono-node/-/chrono-node-1.3.5.tgz",
       "integrity": "sha1-oklSmKMtqCvMAa2b59d++l4kQSI=",
       "requires": {
-        "moment": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
+        "moment": "2.20.1"
       }
     },
     "cli-boxes": {
@@ -317,6 +363,12 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "optional": true
     },
     "configstore": {
       "version": "3.1.1",
@@ -383,6 +435,11 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -398,6 +455,52 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "csv": {
+      "version": "0.4.6",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv/-/csv-0.4.6.tgz",
+      "integrity": "sha1-jbrn3f26rmLB6ph8Pg+Kmsc3tz0=",
+      "requires": {
+        "csv-generate": "0.0.6",
+        "csv-parse": "1.3.3",
+        "csv-stringify": "0.0.8",
+        "stream-transform": "0.1.2"
+      }
+    },
+    "csv-generate": {
+      "version": "0.0.6",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv-generate/-/csv-generate-0.0.6.tgz",
+      "integrity": "sha1-l+TmOuRrIZEs2UdbwxRp0m9a3mY="
+    },
+    "csv-parse": {
+      "version": "1.3.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv-parse/-/csv-parse-1.3.3.tgz",
+      "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+    },
+    "csv-stringify": {
+      "version": "0.0.8",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv-stringify/-/csv-stringify-0.0.8.tgz",
+      "integrity": "sha1-Usw7PfwZd1jFWtMlqVvoUHH55Rs="
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "depd": {
       "version": "1.1.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/depd/-/depd-1.1.1.tgz",
@@ -408,6 +511,11 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-node": {
+      "version": "2.0.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -415,6 +523,15 @@
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.5",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/dtrace-provider/-/dtrace-provider-0.8.5.tgz",
+      "integrity": "sha1-mOu6Ihr6xG4cOf02hY2Pk2dSS5I=",
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0"
       }
     },
     "duplexer3": {
@@ -429,7 +546,7 @@
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
       "requires": {
         "base64url": "2.0.0",
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        "safe-buffer": "5.1.1"
       }
     },
     "ecstatic": {
@@ -497,6 +614,11 @@
       "version": "1.0.3",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-regexp-component": {
+      "version": "1.0.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+      "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
     },
     "etag": {
       "version": "1.8.1",
@@ -723,6 +845,11 @@
         }
       }
     },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/forwarded/-/forwarded-0.1.2.tgz",
@@ -775,6 +902,19 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "optional": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "global-dirs": {
       "version": "0.1.0",
@@ -844,6 +984,11 @@
         }
       }
     },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/has-flag/-/has-flag-2.0.0.tgz",
@@ -851,8 +996,25 @@
       "dev": true
     },
     "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "2.16.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "wbuf": "1.7.2"
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.6.2",
@@ -1000,10 +1162,10 @@
         "ctype": "0.5.3"
       },
       "dependencies": {
-        "ctype": {
-          "version": "0.5.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ctype/-/ctype-0.5.3.tgz",
-          "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
         }
       }
     },
@@ -1017,6 +1179,21 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "optional": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ipaddr.js": {
       "version": "1.5.2",
@@ -1065,6 +1242,11 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isemail": {
       "version": "1.2.0",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/isemail/-/isemail-1.2.0.tgz",
@@ -1084,9 +1266,9 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+        "moment": "2.20.1",
         "topo": "1.1.0"
       }
     },
@@ -1103,8 +1285,8 @@
         "joi": "6.10.1",
         "jws": "3.1.4",
         "lodash.once": "4.1.1",
-        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
       }
     },
     "jsprim": {
@@ -1158,7 +1340,7 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        "safe-buffer": "5.1.1"
       }
     },
     "jws": {
@@ -1168,13 +1350,27 @@
       "requires": {
         "base64url": "2.0.0",
         "jwa": "1.1.5",
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        "safe-buffer": "5.1.1"
       }
+    },
+    "keep-alive-agent": {
+      "version": "0.0.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+      "integrity": "sha1-RIR8o5TOjWtSGuhYFr1kUJlCs4U="
     },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "make-dir": {
       "version": "1.0.0",
@@ -1203,13 +1399,77 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "optional": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "optional": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "optional": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
     "moment": {
-      "version": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.20.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
+      }
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "optional": true
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "node-cache": {
       "version": "4.1.1",
@@ -1984,6 +2244,11 @@
         "path-key": "2.0.1"
       }
     },
+    "obuf": {
+      "version": "1.1.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/obuf/-/obuf-1.1.1.tgz",
+      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
+    },
     "offline-directline": {
       "version": "1.1.5",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/offline-directline/-/offline-directline-1.1.5.tgz",
@@ -2011,6 +2276,14 @@
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
       }
     },
     "p-finally": {
@@ -2053,6 +2326,12 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "optional": true
+    },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/path-is-inside/-/path-is-inside-1.0.2.tgz",
@@ -2070,6 +2349,16 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/promise/-/promise-7.3.1.tgz",
@@ -2086,6 +2375,16 @@
         "forwarded": "0.1.2",
         "ipaddr.js": "1.5.2"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "range-parser": {
       "version": "1.2.0",
@@ -2139,6 +2438,20 @@
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "redis": {
@@ -2524,9 +2837,9 @@
       }
     },
     "restify": {
-      "version": "4.3.1",
-      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/restify/-/restify-4.3.1.tgz",
-      "integrity": "sha1-Yz6AlVTnRCK8KKNOIzzMK+4uiQQ=",
+      "version": "4.3.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/restify/-/restify-4.3.2.tgz",
+      "integrity": "sha512-zPdFHgl2kq8KeQ5bAsya93bEiYzO2nFqroyzI+GyKP8bzufTq2EzFSpaYoCr7CPYVGAOmGFBvwDC2vr+u85KJQ==",
       "requires": {
         "assert-plus": "0.1.5",
         "backoff": "2.5.0",
@@ -2538,7 +2851,7 @@
         "http-signature": "0.11.0",
         "keep-alive-agent": "0.0.1",
         "lru-cache": "4.1.1",
-        "mime": "1.4.1",
+        "mime": "1.6.0",
         "negotiator": "0.6.1",
         "once": "1.4.0",
         "qs": "6.5.1",
@@ -2550,402 +2863,28 @@
         "verror": "1.10.0"
       },
       "dependencies": {
-        "backoff": {
-          "version": "2.5.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/backoff/-/backoff-2.5.0.tgz",
-          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-          "requires": {
-            "precond": "0.2.3"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "optional": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "bunyan": {
-          "version": "1.8.12",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/bunyan/-/bunyan-1.8.12.tgz",
-          "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
-          "requires": {
-            "dtrace-provider": "0.8.5",
-            "moment": "2.19.2",
-            "mv": "2.1.1",
-            "safe-json-stringify": "1.0.4"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "csv": {
-          "version": "0.4.6",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv/-/csv-0.4.6.tgz",
-          "integrity": "sha1-jbrn3f26rmLB6ph8Pg+Kmsc3tz0=",
-          "requires": {
-            "csv-generate": "0.0.6",
-            "csv-parse": "1.3.3",
-            "csv-stringify": "0.0.8",
-            "stream-transform": "0.1.2"
-          }
-        },
-        "csv-generate": {
-          "version": "0.0.6",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv-generate/-/csv-generate-0.0.6.tgz",
-          "integrity": "sha1-l+TmOuRrIZEs2UdbwxRp0m9a3mY="
-        },
-        "csv-parse": {
-          "version": "1.3.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv-parse/-/csv-parse-1.3.3.tgz",
-          "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
-        },
-        "csv-stringify": {
-          "version": "0.0.8",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/csv-stringify/-/csv-stringify-0.0.8.tgz",
-          "integrity": "sha1-Usw7PfwZd1jFWtMlqVvoUHH55Rs="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "detect-node": {
-          "version": "2.0.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/detect-node/-/detect-node-2.0.3.tgz",
-          "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
-        },
-        "dtrace-provider": {
-          "version": "0.8.5",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/dtrace-provider/-/dtrace-provider-0.8.5.tgz",
-          "integrity": "sha1-mOu6Ihr6xG4cOf02hY2Pk2dSS5I=",
-          "optional": true,
-          "requires": {
-            "nan": "2.7.0"
-          }
-        },
-        "escape-regexp-component": {
-          "version": "1.0.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
-          "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
-        },
-        "formidable": {
-          "version": "1.1.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/formidable/-/formidable-1.1.1.tgz",
-          "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
-        },
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "optional": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "handle-thing": {
-          "version": "1.2.5",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/handle-thing/-/handle-thing-1.2.5.tgz",
-          "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
-        },
-        "hpack.js": {
-          "version": "2.1.6",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/hpack.js/-/hpack.js-2.1.6.tgz",
-          "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-          "requires": {
-            "inherits": "2.0.3",
-            "obuf": "1.1.1",
-            "readable-stream": "2.3.3",
-            "wbuf": "1.7.2"
-          }
-        },
-        "http-deceiver": {
-          "version": "1.2.7",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/http-deceiver/-/http-deceiver-1.2.7.tgz",
-          "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "optional": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "keep-alive-agent": {
-          "version": "0.0.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
-          "integrity": "sha1-RIR8o5TOjWtSGuhYFr1kUJlCs4U="
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
-        "minimalistic-assert": {
-          "version": "1.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-          "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "moment": {
-          "version": "2.19.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/moment/-/moment-2.19.2.tgz",
-          "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
-          "optional": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "mv": {
-          "version": "2.1.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/mv/-/mv-2.1.1.tgz",
-          "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "ncp": "2.0.0",
-            "rimraf": "2.4.5"
-          }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "optional": true
-        },
-        "ncp": {
-          "version": "2.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/ncp/-/ncp-2.0.0.tgz",
-          "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-          "optional": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-        },
-        "obuf": {
-          "version": "1.1.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/obuf/-/obuf-1.1.1.tgz",
-          "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "optional": true
-        },
-        "precond": {
-          "version": "0.2.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/precond/-/precond-0.2.3.tgz",
-          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "optional": true,
-          "requires": {
-            "glob": "6.0.4"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "safe-json-stringify": {
-          "version": "1.0.4",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
-          "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
-          "optional": true
-        },
-        "select-hose": {
-          "version": "2.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/select-hose/-/select-hose-2.0.0.tgz",
-          "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
-        },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
-        },
-        "spdy": {
-          "version": "3.4.7",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/spdy/-/spdy-3.4.7.tgz",
-          "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-          "requires": {
-            "debug": "2.6.9",
-            "handle-thing": "1.2.5",
-            "http-deceiver": "1.2.7",
-            "safe-buffer": "5.1.1",
-            "select-hose": "2.0.0",
-            "spdy-transport": "2.0.20"
-          }
-        },
-        "spdy-transport": {
-          "version": "2.0.20",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/spdy-transport/-/spdy-transport-2.0.20.tgz",
-          "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-          "requires": {
-            "debug": "2.6.9",
-            "detect-node": "2.0.3",
-            "hpack.js": "2.1.6",
-            "obuf": "1.1.1",
-            "readable-stream": "2.3.3",
-            "safe-buffer": "5.1.1",
-            "wbuf": "1.7.2"
-          }
-        },
-        "stream-transform": {
-          "version": "0.1.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/stream-transform/-/stream-transform-0.1.2.tgz",
-          "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-        },
-        "wbuf": {
-          "version": "1.7.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/wbuf/-/wbuf-1.7.2.tgz",
-          "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-          "requires": {
-            "minimalistic-assert": "1.0.0"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
         }
+      }
+    },
+    "restify-cors-middleware": {
+      "version": "1.1.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/restify-cors-middleware/-/restify-cors-middleware-1.1.0.tgz",
+      "integrity": "sha512-e8PGGWIKlHAxa0VwjKQ5qasmNRDMPuWeM9TV3a+trWUxk8fRiHyZu/2sirDc4NhARsdAXWDCNqe03PF9KweD9g==",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "optional": true,
+      "requires": {
+        "glob": "6.0.4"
       }
     },
     "rsa-pem-from-mod-exp": {
@@ -2954,8 +2893,25 @@
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "version": "5.1.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-json-stringify": {
+      "version": "1.0.4",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
+      "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
+      "optional": true
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+    },
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
     },
     "send": {
       "version": "0.16.1",
@@ -3034,6 +2990,33 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "requires": {
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.0.20"
+      }
+    },
+    "spdy-transport": {
+      "version": "2.0.20",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/spdy-transport/-/spdy-transport-2.0.20.tgz",
+      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+      "requires": {
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.2"
+      }
+    },
     "sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/sprintf-js/-/sprintf-js-1.1.1.tgz",
@@ -3043,6 +3026,11 @@
       "version": "1.3.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stream-transform": {
+      "version": "0.1.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/stream-transform/-/stream-transform-0.1.2.tgz",
+      "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
     },
     "string-width": {
       "version": "2.1.1",
@@ -3069,6 +3057,14 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-eof": {
@@ -3272,7 +3268,7 @@
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/topo/-/topo-1.1.0.tgz",
       "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        "hoek": "2.16.3"
       }
     },
     "tslib": {
@@ -3443,7 +3439,8 @@
       }
     },
     "url-join": {
-      "version": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-parse-lax": {
@@ -3463,10 +3460,20 @@
         }
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "vary": {
       "version": "1.1.2",
@@ -3499,18 +3506,14 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.2.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        }
+      }
+    },
+    "wbuf": {
+      "version": "1.7.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/wbuf/-/wbuf-1.7.2.tgz",
+      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+      "requires": {
+        "minimalistic-assert": "1.0.0"
       }
     },
     "whatwg-fetch": {
@@ -3570,14 +3573,25 @@
         }
       }
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
     "xmldom": {
       "version": "0.1.27",
       "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://dialearn.pkgs.visualstudio.com/_packaging/BLIS-SDK/npm/registry/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "redis": "^2.7.1",
     "request": "^2.79.0",
     "restify": "^4.3.0",
+    "restify-cors-middleware": "^1.1.0",
     "swagger-client": "^2.1.32",
     "tslib": "^1.5.0",
     "xmldom": "^0.1.27"
@@ -30,6 +31,7 @@
     "@types/redis": "^2.6.0",
     "@types/request": "^2.0.3",
     "@types/restify": "^4.3.5",
+    "@types/restify-cors-middleware": "^1.0.1",
     "@types/xmldom": "^0.1.29",
     "fs-extra": "^1.0.0",
     "http-server": "^0.9.0",

--- a/src/Http/Server.ts
+++ b/src/Http/Server.ts
@@ -8,6 +8,13 @@ import * as XMLDom from 'xmldom';
 import { TrainDialog, BotInfo, 
         BlisAppBase, ActionBase, EntityBase } from 'blis-models'
 import { ScoreInput, UIScoreInput, UIExtractResponse, UIScoreResponse, UITeachResponse, UITrainScorerStep  } from 'blis-models'
+import * as corsMiddleware from 'restify-cors-middleware'
+
+const cors = corsMiddleware({
+    origins: ['*'],
+    allowHeaders: ['authorization'],
+    exposeHeaders: []
+})
 
 export class Server {
     private static server : Restify.Server = null;
@@ -82,11 +89,8 @@ export class Server {
         this.server.use(Restify.queryParser());
 
         //CORS
-        this.server.use(Restify.CORS({
-            origins: ['*'],
-            credentials: true,
-            headers: ['*']
-        }));
+        this.server.pre(cors.preflight)
+        this.server.use(cors.actual)
 
         this.server.on('restifyError', (req: any, res: any, err: any, cb: any) => {
             BlisDebug.Error(err, "ResiftyError");


### PR DESCRIPTION
Somehow the original Restify.CORS plugin was taking headers as input but it didn't actually use the input.  This caused the middleware to reject our OPTIONS request for authorization header even though credentials: true and headers: ['*'] was specified.

Issue: https://github.com/restify/node-restify/issues/1151

See: https://github.com/Tabcorp/restify-cors-middleware