### PR TITLE
Update to allow configuring ports for SDK, DOL service, and DOL bot using environment variables

### DIFF
--- a/src/DOLRunner.ts
+++ b/src/DOLRunner.ts
@@ -2,7 +2,12 @@ import * as directline from "offline-directline";
 import * as express from 'express';
  
 export function InitDOLRunner() {
-    console.log('Starting DOL...'); 
-    const app = express();
-    directline.initializeRoutes(app, "http://127.0.0.1:3000", "http://127.0.0.1:3978/api/messages");
+    const serviceUrl = process.env.DOL_SERVICE_URL || "http://127.0.0.1:3000"
+    const botUrl = process.env.DOL_BOT_URL || "http://127.0.0.1:3978/api/messages"
+    console.log(`Starting DOL (Direct Offline):`)
+    console.log(`- serviceUrl: ${serviceUrl}`)
+    console.log(`- botUrl: ${botUrl}`)
+
+    const app = express()
+    directline.initializeRoutes(app, serviceUrl, botUrl)
 }

--- a/src/Http/Server.ts
+++ b/src/Http/Server.ts
@@ -85,7 +85,9 @@ export class Server {
     }
 
     public static Init() : void{
-        this.server = Restify.createServer();
+        this.server = Restify.createServer({
+            name: `SDK Service`
+        });
 
         this.server.use(Restify.bodyParser());
         this.server.use(Restify.queryParser());
@@ -100,7 +102,8 @@ export class Server {
             return cb();
         });
 
-        this.server.listen(5000, (err : any) =>
+        const port = process.env.BLIS_SDK_PORT || 5000
+        this.server.listen(port, (err : any) =>
         {
             if (err)
             {
@@ -108,7 +111,7 @@ export class Server {
             }
             else
             {
-                BlisDebug.Log(`SDK Service ${this.server.name} listening to ${this.server.url}`);
+                BlisDebug.Log(`${this.server.name} listening to ${this.server.url}`);
             }
         });
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -176,7 +176,7 @@ export class Utils  {
             case "builtin.ordinal":
                 return resolution.value;
             case "builtin.temperature":
-            return resolution.value;
+                return resolution.value;
             case "builtin.dimension":
                 return resolution.value;
             case "builtin.money":

--- a/src/blisUi.ts
+++ b/src/blisUi.ts
@@ -11,7 +11,7 @@ export default function (): { app: express.Express, listener: http.Server } {
     app.use(express.static(blisUi.directoryPath))
     .use((req, res) => res.sendFile(blisUi.defaultFilePath))
     
-    const listener = app.listen(blisUiPort, () => console.log(`Navigate to localhost:${listener.address().port} to view BLIS administration page.`))
+    const listener = app.listen(blisUiPort, () => console.log(`Navigate to http://localhost:${listener.address().port} to view BLIS administration application.`))
 
     return {
         app,


### PR DESCRIPTION
An alternative is to make code changes to allow passing the ports and urls down through in configuration / options objects.  This is probably the more technically correct approach since it allows the host process to isolate configuration to single layer and do merging and not rely on environment variables throughout the stack, but they were the simplest approach to do what we needed.