### PR TITLE
Update blis-sdk to take in configuration as parameters instead of relying on environment variables set from consuming project

### DIFF
--- a/src/Blis.ts
+++ b/src/Blis.ts
@@ -6,7 +6,7 @@ import { BlisMemory } from './BlisMemory'
 import { BlisDebug } from './BlisDebug'
 import { BlisClient } from './BlisClient'
 import createSdkServer from './Http/Server'
-import { InitDOLRunner } from './DOLRunner'
+import { startDirectOffLineServer } from './DOLRunner'
 import { TemplateProvider } from './TemplateProvider'
 import { Utils } from './Utils'
 import {
@@ -66,12 +66,11 @@ export class Blis {
 
             // If app not set, assume running on localhost init DOL Runner
             if (options.localhost) {
-                InitDOLRunner()
+                startDirectOffLineServer(options.dolServiceUrl, options.dolBotUrl)
             }
 
-            const port = process.env.BLIS_SDK_PORT || 5000
             const sdkServer = createSdkServer(this.blisClient)
-            sdkServer.listen(port, (err: any) => {
+            sdkServer.listen(options.sdkPort, (err: any) => {
                 if (err) {
                     BlisDebug.Error(err, 'Server/Init')
                 } else {

--- a/src/BlisOptions.ts
+++ b/src/BlisOptions.ts
@@ -1,22 +1,12 @@
 export interface IBlisOptions {
     // URL for BLIS service
     serviceUri: string
-
-    // BLIS User Name
-    user: string
-
-    // BLIS Secret
-    secret: string
-
+    sdkPort: number
+    uiPort: number
     // Application to start
     appId: string
-
-    // End point for Azure function calls
-    azureFunctionsUrl?: string
-
-    // Key for Azure function calls (optional)
-    azureFunctionsKey?: string
-
     // Running on localhost
     localhost?: boolean
+    dolBotUrl: string
+    dolServiceUrl: string
 }

--- a/src/DOLRunner.ts
+++ b/src/DOLRunner.ts
@@ -1,8 +1,6 @@
 import * as directline from 'offline-directline'
 import * as express from 'express'
-export function InitDOLRunner() {
-    const serviceUrl = process.env.DOL_SERVICE_URL || 'http://127.0.0.1:3000'
-    const botUrl = process.env.DOL_BOT_URL || 'http://127.0.0.1:3978/api/messages'
+export function startDirectOffLineServer(serviceUrl: string, botUrl: string) {
     console.log(`Starting DOL (Direct Offline):`)
     console.log(`- serviceUrl: ${serviceUrl}`)
     console.log(`- botUrl: ${botUrl}`)

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -1,4 +1,5 @@
 import * as BB from 'botbuilder'
+import { Blis } from '../Blis'
 import { BlisMemory } from '../BlisMemory'
 import { BlisAppBase } from 'blis-models'
 import { BlisIntent } from '../BlisIntent'
@@ -146,7 +147,8 @@ export class BotState {
             user: { name: userName, id: userId },
             conversation: { id: conversationId },
             channelId: 'emulator',
-            serviceUrl: process.env.DOL_SERVICE_URL || 'http://127.0.0.1:3000'
+            // TODO: Refactor away from static coupling.  BotState needs to have access to options object through constructor
+            serviceUrl: Blis.options.dolServiceUrl
         }
         this.SetConversationReferenceAsync(conversationReference)
     }

--- a/src/blisUi.ts
+++ b/src/blisUi.ts
@@ -2,15 +2,14 @@ import * as express from 'express'
 import * as http from 'http'
 import * as blisUi from 'blis-ui'
 
-export default function(): { app: express.Express; listener: http.Server } {
+export default function(port: number = 5050): { app: express.Express; listener: http.Server } {
     console.log(`blis-ui directory path: `, blisUi.directoryPath)
     console.log(`blis-ui default file path: `, blisUi.defaultFilePath)
 
-    const blisUiPort = parseInt(process.env.BLIS_UI_PORT) || 5050
     const app = express()
     app.use(express.static(blisUi.directoryPath)).use((req, res) => res.sendFile(blisUi.defaultFilePath))
 
-    const listener = app.listen(blisUiPort, () =>
+    const listener = app.listen(port, () =>
         console.log(`Navigate to http://localhost:${listener.address().port} to view BLIS administration application.`)
     )
 


### PR DESCRIPTION
This is step in making SDK more flexible since config is no longer tied to env vars. Consumers should be able to run two different isntances without having to run separate processes for env isolation