### PR TITLE
1137: 500 error (on SDK) when attempting to refresh list of cards and…

### DIFF
--- a/src/TemplateProvider.ts
+++ b/src/TemplateProvider.ts
@@ -111,7 +111,7 @@ export class TemplateProvider {
         try {
             let fileNames: string[] = fs.readdirSync(templateDirectory)
             fileNames = fileNames.filter(fn => fn.endsWith('.json'))
-            let templates = fileNames.map(f => f.slice(0, f.indexOf('.')))
+            let templates = fileNames.map(f => f.slice(0, f.lastIndexOf('.')))
             return templates
         } catch {
             BlisDebug.Log("No Card directory found")


### PR DESCRIPTION
… current card isn't present

Filename issue