### PR TITLE
1147: Update live version of app at session boundary

### DIFF
--- a/src/BlisMemory.ts
+++ b/src/BlisMemory.ts
@@ -161,7 +161,7 @@ export class BlisMemory {
             if (!calledEndSession) {
 
                 // Default callback will clear the bot memory
-                Blis.CallSessionEndCallback(this, app ? app.appId : null);
+                await Blis.CallSessionEndCallback(this, app ? app.appId : null);
             }
         }
         await Blis.CallSessionStartCallback(this, app ? app.appId : null);

--- a/src/Http/Server.ts
+++ b/src/Http/Server.ts
@@ -274,7 +274,7 @@ export const createSdkServer = (client: BlisClient, options: restify.ServerOptio
 
             // Get lookup table for which apps packages are being edited
             let memory = BlisMemory.GetMemory(key)
-            let activeApps = await memory.BotState.ActiveAppsAsync();
+            let activeApps = await memory.BotState.EditingPackagesAsync();
 
             let uiAppList = { appList: apps, activeApps: activeApps } as models.UIAppList;
             res.send(uiAppList)
@@ -380,7 +380,7 @@ export const createSdkServer = (client: BlisClient, options: restify.ServerOptio
             }
 
             let memory = BlisMemory.GetMemory(key)
-            let updatedPackageVersions = await memory.BotState.SetActiveAppAsync(appId, packageId);
+            let updatedPackageVersions = await memory.BotState.SetEditingPackageAsync(appId, packageId);
             res.send(updatedPackageVersions)
 
         } catch (error) {

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -46,7 +46,7 @@ export class BotState {
     public conversationReference: BB.ConversationReference | null = null
 
     // Which packages are active for editing
-    public activeApps: { [appId: string]: string };  // appId: packageId
+    public editingPackages: { [appId: string]: string };  // appId: packageId
 
     private constructor(init?: Partial<BotState>) {
         (<any>Object).assign(this, init)
@@ -84,7 +84,7 @@ export class BotState {
         this.orgSessionId = json.orgSessionId,
         this.onEndSessionCalled = json.onEndSessionCalled ? json.onEndSessionCalled : false
         this.conversationReference = json.conversationReference,
-        this.activeApps = json.activeApps
+        this.editingPackages = json.activeApps
     }
 
     private Serialize(): string {
@@ -97,7 +97,7 @@ export class BotState {
             orgSessionId: this.orgSessionId,
             onEndSessionCalled: this.onEndSessionCalled ? this.onEndSessionCalled : false,
             conversationReference: this.conversationReference,
-            activeApps: this.activeApps
+            activeApps: this.editingPackages
         }
         return JSON.stringify(jsonObj)
     }
@@ -118,7 +118,7 @@ export class BotState {
         this.orgSessionId = null
         this.onEndSessionCalled = false
         this.inTeach = false
-        this.activeApps = {}
+        this.editingPackages = {}
         await this.SetAsync()
     }
 
@@ -136,21 +136,21 @@ export class BotState {
         return this.conversationId
     }
 
-    public async ActiveAppsAsync(): Promise<{ [appId: string]: string }> {
+    public async EditingPackagesAsync(): Promise<{ [appId: string]: string }> {
         await this.Init()
-        return this.activeApps
+        return this.editingPackages
     }
 
-    public async SetActiveAppAsync(appId: string, packageId: string): Promise<{ [appId: string]: string }> {
+    public async SetEditingPackageAsync(appId: string, packageId: string): Promise<{ [appId: string]: string }> {
         await this.Init()
-        this.activeApps[appId] = packageId;
+        this.editingPackages[appId] = packageId;
         await this.SetAsync();
-        return this.activeApps;
+        return this.editingPackages;
     }
 
-    public async ActiveAppAsync(appId: string): Promise<string> {
+    public async EditingPackageAsync(appId: string): Promise<string> {
         await this.Init()
-        return this.activeApps[appId];
+        return this.editingPackages[appId];
     }
 
     public async OrgSessionIdAsync(sessionId: string): Promise<string | null> {


### PR DESCRIPTION
Live bot should stay on live version tag until session ends then switch to new one