### PR TITLE
Add guard statement in process input to return error message if there is no LUIS authoring key

### DIFF
--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -217,6 +217,14 @@ export class CLRunner {
                 return null
             }
 
+            if (!ConversationLearner.options || !ConversationLearner.options.luisAuthoringKey) {
+                // TODO: Remove mention of environment variables. They are not guaranteed and are part of different repository.
+                let msg =  'Options must specify luisAuthoringKey.  Set the LUIS_AUTHORING_KEY environment variable.\n\n'
+                CLDebug.Error(msg)
+                await this.SendMessage(memory, msg)
+                return null
+            }
+
             let inTeach = await memory.BotState.InTeachAsync()
             let inEditingUI = 
                 conversationReference.user &&


### PR DESCRIPTION
There is issue of specifying environment variables in the log messages that would need to be fixed but since it's already done in other places for app id I didn't want this PR to change too much.

Opened: https://dialearn.visualstudio.com/BLIS/_workitems/edit/1210