### PR TITLE
fix: enable strict checks for typescript compilation

### DIFF
--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import * as BB from 'botbuilder'
-import { CLRunner } from './CLRunner'
+import { CLRunner, ApiCallback, EntityDetectionCallback, OnSessionStartCallback, OnSessionEndCallback } from './CLRunner'
 import { ICLOptions } from './CLOptions'
 import { CLMemory } from './CLMemory'
 import { CLDebug } from './CLDebug'
@@ -11,7 +11,6 @@ import { CLClient } from './CLClient'
 import createSdkServer from './Http/Server'
 import { startDirectOffLineServer } from './DOLRunner'
 import { CL_DEVELOPER, DEFAULT_MAX_SESSION_LENGTH } from './Utils'
-import { ClientMemoryManager } from './Memory/ClientMemoryManager'
 import { CLRecognizerResult } from './CLRecognizeResult'
 
 export class ConversationLearner {
@@ -79,9 +78,7 @@ export class ConversationLearner {
     /**
      * Provide an callback that will be invoked whenever a Session is started
      */
-    public OnSessionStartCallback(
-        target: (context: BB.TurnContext, memoryManager: ClientMemoryManager) => Promise<void>
-    ) {
+    public OnSessionStartCallback(target: OnSessionStartCallback) {
         this.clRunner.onSessionStartCallback = target
     }
     
@@ -89,14 +86,12 @@ export class ConversationLearner {
      * Provide a callback that will be invoked whenever a Session ends.  Sessions
      * can end because of a timeout or the selection of an EndSession activity
      */
-    public OnSessionEndCallback(
-        target: (context: BB.TurnContext, memoryManager: ClientMemoryManager, content: string | undefined) => Promise<string[] | null>
-    ) {
+    public OnSessionEndCallback(target: OnSessionEndCallback) {
         this.clRunner.onSessionEndCallback = target
     }
 
     public async SendResult(result: CLRecognizerResult): Promise<void> {
-        this.clRunner.SendIntent(result);
+        return this.clRunner.SendIntent(result)
     }
 
     // Returns true is bot is running in the Training UI
@@ -104,16 +99,11 @@ export class ConversationLearner {
         return (context.activity.from.name === CL_DEVELOPER);
     }
 
-    public AddAPICallback(
-        name: string,
-        target: (memoryManager: ClientMemoryManager, ...args: string[]) => Promise<Partial<BB.Activity> | string | void>
-    ) {
+    public AddAPICallback(name: string, target: ApiCallback) {
         this.clRunner.AddAPICallback(name, target);
     }
 
-    public EntityDetectionCallback(
-        target: (text: string, memoryManager: ClientMemoryManager) => Promise<void>
-    ) {
+    public EntityDetectionCallback(target: EntityDetectionCallback) {
         this.clRunner.entityDetectionCallback = target
     }
 }

--- a/src/Memory/BotMemory.ts
+++ b/src/Memory/BotMemory.ts
@@ -10,9 +10,9 @@ import { ClientMemoryManager } from '..';
 const NEGATIVE_PREFIX = '~'
 
 export class BotMemory {
-    private static _instance: BotMemory | null = null
+    private static _instance: BotMemory | undefined
     private static MEMKEY = 'BOTMEMORY'
-    private memory: CLMemory
+    private memory: CLMemory | undefined
     public filledEntityMap: FilledEntityMap
 
     private constructor(init?: Partial<BotMemory>) {
@@ -78,7 +78,7 @@ export class BotMemory {
     }
 
     // Clear memory values not in saveList
-    public async ClearAsync(saveList?: string[] | null): Promise<void> {
+    public async ClearAsync(saveList?: string[] | undefined): Promise<void> {
 
         if (!saveList) {
             this.filledEntityMap = new FilledEntityMap()

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -61,8 +61,8 @@ export enum BotStateType {
 }
 
 export class BotState {
-    private static _instance: BotState | null = null
-    public memory: CLMemory
+    private static _instance: BotState | undefined
+    public memory: CLMemory | undefined
 
     private constructor(init?: Partial<BotState>) {
         (<any>Object).assign(this, init)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noImplicitAny": true,
-        "strictNullChecks": true,
+        "strict": true,
         "suppressImplicitAnyIndexErrors": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,


### PR DESCRIPTION
Make sure variables have proper initiation and can't be accessed when they are possibly undefined.