### PR TITLE
fix: convref reset when app starts

### DIFF
--- a/src/CLMemory.ts
+++ b/src/CLMemory.ts
@@ -122,11 +122,11 @@ export class CLMemory {
         }
     }
 
-    public async SetAppAsync(app: AppBase | null): Promise<void> {
-        const curApp = await this.BotState.GetApp();
-        await this.BotState._SetAppAsync(app)
+    public async SetAppAsync(newApp: AppBase | null): Promise<void> {
+        const prevApp = await this.BotState.GetApp();
+        await this.BotState._SetAppAsync(newApp, prevApp)
 
-        if (!app || !curApp || curApp.appId !== app.appId) {
+        if (!newApp || !prevApp || prevApp.appId !== newApp.appId) {
             await this.BotMemory.ClearAsync()
         }
     }

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -172,7 +172,7 @@ export class CLRunner {
     }
 
     // Get the currently running app
-    private async GetApp(memory: CLMemory, inEditingUI: boolean) : Promise<CLM.AppBase | null> {
+    private async GetRunningApp(memory: CLMemory, inEditingUI: boolean) : Promise<CLM.AppBase | null> {
 
         let app = await memory.BotState.GetApp()
 
@@ -257,7 +257,7 @@ export class CLRunner {
                 return null
             }
 
-            let app = await this.GetApp(clMemory, inEditingUI);
+            let app = await this.GetRunningApp(clMemory, inEditingUI);
             
             if (!app) {
                 let error = "ERROR: AppId not specified.  When running in a channel (i.e. Skype) or the Bot Framework Emulator, CONVERSATION_LEARNER_MODEL_ID must be specified in your Bot's .env file or Application Settings on the server"

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -105,19 +105,23 @@ export class BotState {
     }
 
     // NOTE: CLMemory should be the only one to call this
-    public async _SetAppAsync(app: AppBase | null): Promise<void> {
-        await this.SetApp(app)
-        await this.SetConversationId(null)
-        await this.SetConversationReference(null)
-        await this.SetLastActive(0);
-        await this.SetMessageProcessing(null);
-        await this.SetOrgSessionId(null)
-        await this.SetNeedSessionStartCall(false)
-        await this.SetNeedSessionEndCall(false)
-        await this.SetInTeach(false)
-        await this.SetSessionId(null)
-        await this.SetLogDialogId(null);
-        await this.ClearEditingPackageAsync();
+    public async _SetAppAsync(newApp: AppBase | null, prevApp: AppBase | null = null): Promise<void> {
+        await this.SetApp(newApp)
+
+        // If no app or I had a previous app, reset my state
+        if (newApp == null || prevApp) {
+            await this.SetConversationId(null)
+            await this.SetConversationReference(null)
+            await this.SetLastActive(0);
+            await this.SetMessageProcessing(null);
+            await this.SetOrgSessionId(null)
+            await this.SetNeedSessionStartCall(false)
+            await this.SetNeedSessionEndCall(false)
+            await this.SetInTeach(false)
+            await this.SetSessionId(null)
+            await this.SetLogDialogId(null);
+            await this.ClearEditingPackageAsync();
+        }
     }
 
     // ------------------------------------------------


### PR DESCRIPTION
Setting model from config cleared conversation ref.  Only needs to be cleared if the model has changed.  Bug only showed up when memory store was cleared and running off of config model id