### PR TITLE
fix: change return type of OnSessionEndCallback to allow void

### DIFF
--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -42,7 +42,7 @@ export type OnSessionStartCallback = (context: BB.TurnContext, memoryManager: Cl
  * If implemented, developer may return a list of entities to preserve for the next session
  * as well as store them in the Bot State
  */
-export type OnSessionEndCallback = (context: BB.TurnContext, memoryManager: ClientMemoryManager, sessionEndState: CLM.SessionEndState, data: string | undefined) => Promise<string[] | undefined>
+export type OnSessionEndCallback = (context: BB.TurnContext, memoryManager: ClientMemoryManager, sessionEndState: CLM.SessionEndState, data: string | undefined) => Promise<string[] | void>
 
 /**
  * Called when the associated API Action in your bot is sent.

--- a/src/Memory/BotMemory.ts
+++ b/src/Memory/BotMemory.ts
@@ -78,8 +78,7 @@ export class BotMemory {
     }
 
     // Clear memory values not in saveList
-    public async ClearAsync(saveList?: string[] | undefined): Promise<void> {
-
+    public async ClearAsync(saveList?: string[] | void): Promise<void> {
         if (!saveList) {
             this.filledEntityMap = new FilledEntityMap()
         }


### PR DESCRIPTION
allows developers to not return anything instead of having to explicitly return `undefined` which is unnatural as undefined is implied with no return value.