### PR TITLE
fix: changing modelId while in emulator

### DIFF
--- a/src/CLMemory.ts
+++ b/src/CLMemory.ts
@@ -122,11 +122,11 @@ export class CLMemory {
         }
     }
 
-    public async SetAppAsync(newApp: AppBase | null): Promise<void> {
-        const prevApp = await this.BotState.GetApp();
-        await this.BotState._SetAppAsync(newApp, prevApp)
+    public async SetAppAsync(app: AppBase | null): Promise<void> {
+        const curApp = await this.BotState.GetApp();
+        await this.BotState._SetAppAsync(app)
 
-        if (!newApp || !prevApp || prevApp.appId !== newApp.appId) {
+        if (!app || !curApp || curApp.appId !== app.appId) {
             await this.BotMemory.ClearAsync()
         }
     }

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -105,23 +105,19 @@ export class BotState {
     }
 
     // NOTE: CLMemory should be the only one to call this
-    public async _SetAppAsync(newApp: AppBase | null, prevApp: AppBase | null = null): Promise<void> {
-        await this.SetApp(newApp)
-
-        // If no app or I had a previous app, reset my state
-        if (newApp == null || prevApp) {
-            await this.SetConversationId(null)
-            await this.SetConversationReference(null)
-            await this.SetLastActive(0);
-            await this.SetMessageProcessing(null);
-            await this.SetOrgSessionId(null)
-            await this.SetNeedSessionStartCall(false)
-            await this.SetNeedSessionEndCall(false)
-            await this.SetInTeach(false)
-            await this.SetSessionId(null)
-            await this.SetLogDialogId(null);
-            await this.ClearEditingPackageAsync();
-        }
+    public async _SetAppAsync(app: AppBase | null): Promise<void> {
+        await this.SetApp(app)
+        await this.SetConversationId(null)
+        await this.SetConversationReference(null)
+        await this.SetLastActive(0);
+        await this.SetMessageProcessing(null);
+        await this.SetOrgSessionId(null)
+        await this.SetNeedSessionStartCall(false)
+        await this.SetNeedSessionEndCall(false)
+        await this.SetInTeach(false)
+        await this.SetSessionId(null)
+        await this.SetLogDialogId(null);
+        await this.ClearEditingPackageAsync();
     }
 
     // ------------------------------------------------


### PR DESCRIPTION
fix: Reordered ProcessInput loop to better handle changing of modelId mid-flight when bot is running
fix: 403 error was displaying at 500 in UI (try catch around endSessionasync)
fix: prevent double error message display