### PR TITLE
fix: wrong app possible in hybrid bot

### DIFF
--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -134,8 +134,8 @@ export class CLRunner {
         }
 
         try {
+            let app = await this.GetRunningApp(activity.from.id, false);
             let clMemory = await CLMemory.InitMemory(activity.from, conversationReference)
-            let app = await clMemory.BotState.GetApp()
         
             if (app) {
                 let packageId = (app.livePackageId || app.devPackageId)


### PR DESCRIPTION
Fixed edge case where swiching .env file Model while running in emulator could end up with CL choosing the previously picked Model