### PR TITLE
feat: add set entity actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4271,8 +4271,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4293,14 +4292,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4315,20 +4312,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4445,8 +4439,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4458,7 +4451,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4473,7 +4465,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4481,14 +4472,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4507,7 +4496,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4588,8 +4576,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4601,7 +4588,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4687,8 +4673,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4724,7 +4709,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4744,7 +4728,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4788,14 +4771,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -405,9 +405,9 @@
       "integrity": "sha512-N2TtGCmjwNIzAqDCN9mwSpzu3ygB5PEXPEkoxUxOY3oHoDZpAtLRmxc0jMdlK/8StzBXwdhJnVbnY1trmoFqkA=="
     },
     "@conversationlearner/ui": {
-      "version": "0.353.21",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.353.21.tgz",
-      "integrity": "sha512-c+/wdp2qlYvJI4haCpiAWNRj970/SPmPzZu0qRpV+P77gXPhWvPtTrcmZOmyTaoTa12n07vmzt4MHXba1DhVww=="
+      "version": "0.355.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.355.0.tgz",
+      "integrity": "sha512-19o+C6PDcqR68Y2vDYk0LuErr5wdBkK3XeHa78+tZw1xDTMRsrrAormVK+h4eRq8xX2OB+tXzPaGr7h5y23nXQ=="
     },
     "@jest/console": {
       "version": "24.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -400,9 +400,9 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.199.3",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.199.3.tgz",
-      "integrity": "sha512-OL3saxD8/9UOUyDvcNSqH4JzgXPKSMK/DrY3BbgxBvHj5UJyU6LP3huvL6KzFFYpcUf6/SK6wjA6gdC21XSoVw=="
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.200.0.tgz",
+      "integrity": "sha512-N2TtGCmjwNIzAqDCN9mwSpzu3ygB5PEXPEkoxUxOY3oHoDZpAtLRmxc0jMdlK/8StzBXwdhJnVbnY1trmoFqkA=="
     },
     "@conversationlearner/ui": {
       "version": "0.353.21",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@conversationlearner/models": "0.200.0",
-    "@conversationlearner/ui": "0.353.21",
+    "@conversationlearner/ui": "0.355.0",
     "@types/supertest": "2.0.4",
     "async-file": "^2.0.2",
     "body-parser": "1.18.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Microsoft Conversation Learner Team",
   "license": "MIT",
   "dependencies": {
-    "@conversationlearner/models": "0.199.3",
+    "@conversationlearner/models": "0.200.0",
     "@conversationlearner/ui": "0.353.21",
     "@types/supertest": "2.0.4",
     "async-file": "^2.0.2",

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -1110,7 +1110,7 @@ export class CLRunner {
             const error: Error = e
             const title = error.message || `Exception hit when calling Set Entity Action: '${action.actionId}'`
             const message = this.RenderErrorCard(title, error.stack || error.message || "")
-            const replayError = new CLM.ReplayErrorAPIException()
+            const replayError = new CLM.ReplaySetEntityException()
             return {
                 logicResult: undefined,
                 response: message,

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -90,7 +90,7 @@ interface IActionInputLogic {
     logicResult: CLM.LogicResult | undefined
 }
 interface IActionInputRenderOnly {
-    type: ActionInputType.LOGIC_AND_RENDER | ActionInputType.LOGIC_ONLY
+    type: Exclude<ActionInputType, ActionInputType.RENDER_ONLY>
 }
 
 type IActionInput = IActionInputRenderOnly | IActionInputLogic
@@ -1079,16 +1079,16 @@ export class CLRunner {
 
             const entity = allEntities.find(e => e.entityId === action.entityId)
             if (!entity) {
-                throw new Error(`Set Entity Action (${action.actionId}) could not find the referenced entity with id: ${action.entityId}`)
+                throw new Error(`Set Entity Action: ${action.actionId} could not find the referenced entity with id: ${action.entityId}`)
             }
 
             if (entity.entityType !== CLM.EntityType.ENUM) {
-                throw new Error(`Set Entity Action (${action.actionId}) referenced entity ${entity.entityName} but it is not an ENUM. Please update the action to reference the correct entity.`)
+                throw new Error(`Set Entity Action: ${action.actionId} referenced entity ${entity.entityName} but it is not an ENUM. Please update the action to reference the correct entity.`)
             }
 
             const enumValueObj = (entity.enumValues && entity.enumValues.find(ev => ev.enumValueId === action.enumValueId))
             if (!enumValueObj) {
-                throw new Error(`Set Entity Action: (${action.actionId}) which sets: ${entity.entityName} could not find the value with id: ${action.enumValueId}`)
+                throw new Error(`Set Entity Action: ${action.actionId} which sets: ${entity.entityName} could not find the value with id: ${action.enumValueId}`)
             }
 
             // TODO: Is there more efficient way to do this, like editing memory directly?

--- a/src/upgrade.test.ts
+++ b/src/upgrade.test.ts
@@ -125,7 +125,9 @@ describe('upgrade', () => {
                 suggestedEntity: null,
                 version: 0,
                 packageCreationId: 0,
-                packageDeletionId: 0
+                packageDeletionId: 0,
+                entityId: undefined,
+                enumValueId: undefined,
             }
 
             const callbackMap: CallbackMap = {}
@@ -170,7 +172,9 @@ describe('upgrade', () => {
                 suggestedEntity: null,
                 version: 0,
                 packageCreationId: 0,
-                packageDeletionId: 0
+                packageDeletionId: 0,
+                entityId: undefined,
+                enumValueId: undefined,
             }
 
             const callbackMap: CallbackMap = {}
@@ -233,7 +237,9 @@ describe('upgrade', () => {
                 suggestedEntity: null,
                 version: 0,
                 packageCreationId: 0,
-                packageDeletionId: 0
+                packageDeletionId: 0,
+                entityId: undefined,
+                enumValueId: undefined,
             }
 
             const appDefinition: models.AppDefinition = {


### PR DESCRIPTION
- Adds new `TakeSetEntityAction` similar to the `TakeTextAction` and `TakeAPIAction`
- Uses the new `ReplaySetEntityException` for errors during this.
- Use proper discriminated union on `IActionInput`

When taking the action during teaching it displays a placeholder card similar to the API actions.

![image](https://user-images.githubusercontent.com/2856501/56770814-cd979080-6769-11e9-857d-1007494534af.png)

I chose the text `memory.Set(entityName, VALUE)` hoping to show the users what the affect of taking the action is doing to the memory and how they could simulate it within API callbacks if they wanted to do it themselves.  Open to more ideas though. 

Cons that I see are too technical, or takes up two much vertical space.
Could remove the card title or text to consolidate although if we do it for this type we should probably do it for the rest.