### PR TITLE
fix: remove unnecessary interception

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -405,9 +405,9 @@
       "integrity": "sha512-N2TtGCmjwNIzAqDCN9mwSpzu3ygB5PEXPEkoxUxOY3oHoDZpAtLRmxc0jMdlK/8StzBXwdhJnVbnY1trmoFqkA=="
     },
     "@conversationlearner/ui": {
-      "version": "0.355.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.355.0.tgz",
-      "integrity": "sha512-19o+C6PDcqR68Y2vDYk0LuErr5wdBkK3XeHa78+tZw1xDTMRsrrAormVK+h4eRq8xX2OB+tXzPaGr7h5y23nXQ=="
+      "version": "0.356.3",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.356.3.tgz",
+      "integrity": "sha512-O+1JE5dPEpUEDHHB1lS25/u0Vrn8v0DJVJ+UdJDCNng/Ir4JPFnylSSDlqvgeAqrWIbNti0zEGnX5aHacIwf9A=="
     },
     "@jest/console": {
       "version": "24.3.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@conversationlearner/models": "0.200.0",
-    "@conversationlearner/ui": "0.355.0",
+    "@conversationlearner/ui": "0.356.3",
     "@types/supertest": "2.0.4",
     "async-file": "^2.0.2",
     "body-parser": "1.18.3",

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -500,19 +500,6 @@ export const getRouter = (client: CLClient, options: ICLClientOptions): express.
         }
     })
 
-    router.get('/app/:appId/logdialogs', async (req, res, next) => {
-        const { appId } = req.params
-
-        try {
-            const { packageId } = getQuery(req)
-            const packageIds = packageId.split(",")
-            const logDialogs = await client.GetLogDialogs(appId, packageIds)
-            res.send(logDialogs)
-        } catch (error) {
-            HandleError(res, error)
-        }
-    })
-
     //========================================================
     // TrainDialogs
     //========================================================


### PR DESCRIPTION
Guess I missed this one in previous clean up. Allows client to send `excludeConverted` parameter