### PR TITLE
fix: always send saveDialog parameter

### DIFF
--- a/src/CLClient.ts
+++ b/src/CLClient.ts
@@ -384,7 +384,7 @@ export class CLClient {
      * To delete the associated trainDialog, call DELETE on the trainDialog.
      */
     public EndTeach(appId: string, teachId: string, save: boolean): Promise<CLM.TrainResponse> {
-        const query = save ? `saveDialog=${save}` : ''
+        const query = `saveDialog=${save}`
         let apiPath = `app/${appId}/teach/${teachId}`
         return this.send('DELETE', this.MakeURL(apiPath, query))
     }


### PR DESCRIPTION
Fix the 404 Resource Not Found error due to #441 which stopped sending the parameter when false.