### PR TITLE
fix: get conversation id from conversation object in msteams

### DIFF
--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -16,7 +16,7 @@ import { CLRecognizerResult } from './CLRecognizeResult'
 import { ConversationLearner } from './ConversationLearner'
 import { InputQueue } from './Memory/InputQueue'
 import * as util from 'util'
-import { UIMode } from './Memory/BotState';
+import { UIMode, ConversationIdObject } from './Memory/BotState'
 
 interface RunnerLookup {
     [appId: string]: CLRunner
@@ -273,7 +273,7 @@ export class CLRunner {
         }
     }
 
-    public async StartSessionAsync(clMemory: CLMemory, conversationId: string | null, appId: string, sessionStartFlags: SessionStartFlags, createParams: CLM.SessionCreateParams | CLM.CreateTeachParams): Promise<CLM.Teach | CLM.Session> {
+    public async StartSessionAsync(clMemory: CLMemory, conversationId: string | ConversationIdObject | null, appId: string, sessionStartFlags: SessionStartFlags, createParams: CLM.SessionCreateParams | CLM.CreateTeachParams): Promise<CLM.Teach | CLM.Session> {
 
         const inTeach = ((sessionStartFlags & SessionStartFlags.IN_TEACH) > 0)
         let entityList = await this.clClient.GetEntities(appId)
@@ -310,7 +310,7 @@ export class CLRunner {
             logDialogId = startResponse.logDialogId
         }
 
-        // Initizize Bot State
+        // Initialize Bot State
         await clMemory.BotState.InitSessionAsync(sessionId, logDialogId, conversationId, sessionStartFlags)
 
         CLDebug.Verbose(`Started Session: ${sessionId} - ${conversationId}`)

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -16,17 +16,21 @@ export interface ConversationSession {
 
 export interface ConversationIdObject {
     activityId: string
-    user: {
-        id: string
-        name: string
-        aadObjectId?: string
-    },
-    bot: {
-        id: string
-        name: string
-    },
+    user: User
+    bot: Bot
     conversation: Conversation
     channelId: "msteams" | string
+}
+
+interface User {
+    id: string
+    name: string
+    aadObjectId?: string
+}
+
+interface Bot {
+    id: string
+    name: string
 }
 
 interface Conversation {

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -14,6 +14,28 @@ export interface ConversationSession {
     conversationId: string | null
 }
 
+interface ConversationIdObject {
+    activityId: string
+    user: {
+        id: string
+        name: string
+        aadObjectId?: string
+    },
+    bot: {
+        id: string
+        name: string
+    },
+    conversation: Conversation
+    channelId: "msteams" | string
+}
+
+interface Conversation {
+    id: string
+    isGroup?: boolean
+    conversationType: "channel" | "personal" | string
+    tenantId?: string
+}
+
 export interface SessionInfo {
     userName: string,
     userId: string,
@@ -153,8 +175,8 @@ export class BotState {
     // ------------------------------------------------
     //  CONVERSATION_ID
     // ------------------------------------------------
-    public async GetConversationId(): Promise<string | null> {
-        return await this.GetStateAsync<string | null>(BotStateType.CONVERSATION_ID)
+    public async GetConversationId(): Promise<string | ConversationIdObject | null> {
+        return await this.GetStateAsync<string | ConversationIdObject | null>(BotStateType.CONVERSATION_ID)
     }
 
     public async SetConversationId(conversationId: string | null): Promise<void> {
@@ -220,12 +242,12 @@ export class BotState {
             return await this.GetStateAsync<string | null>(BotStateType.SESSION_ID)
         }
         // If conversation Id matches return the sessionId
-        else if (existingConversationId == conversationId) {
+        else if (existingConversationId === conversationId) {
             return await this.GetStateAsync<string | null>(BotStateType.SESSION_ID)
         }
         // If existingConversationId Id is a object - TEAMs Channel 
         else if (typeof existingConversationId === 'object') {
-            if (existingConversationId["user"]["id"] == conversationId) {
+            if (existingConversationId.conversation.id === conversationId) {
                 return await this.GetStateAsync<string | null>(BotStateType.SESSION_ID)
             }
         }

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -14,7 +14,7 @@ export interface ConversationSession {
     conversationId: string | null
 }
 
-interface ConversationIdObject {
+export interface ConversationIdObject {
     activityId: string
     user: {
         id: string
@@ -179,7 +179,7 @@ export class BotState {
         return await this.GetStateAsync<string | ConversationIdObject | null>(BotStateType.CONVERSATION_ID)
     }
 
-    public async SetConversationId(conversationId: string | null): Promise<void> {
+    public async SetConversationId(conversationId: string | ConversationIdObject | null): Promise<void> {
         await this.SetStateAsync(BotStateType.CONVERSATION_ID, conversationId)
     }
 
@@ -264,7 +264,7 @@ export class BotState {
         await this.SetStateAsync(BotStateType.SESSION_ID, sessionId)
     }
 
-    public async InitSessionAsync(sessionId: string | null, logDialogId: string | null, conversationId: string | null, sessionStartFlags: SessionStartFlags): Promise<void> {
+    public async InitSessionAsync(sessionId: string | null, logDialogId: string | null, conversationId: string | ConversationIdObject | null, sessionStartFlags: SessionStartFlags): Promise<void> {
         await this.SetSessionId(sessionId);
         await this.SetLogDialogId(logDialogId)
         await this.SetNeedSessionEndCall(true)

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -14,6 +14,10 @@ export interface ConversationSession {
     conversationId: string | null
 }
 
+/**
+ * When using Microsoft Teams the Conversation Id is set to a complex object rather than simple string
+ * It contains information about the user, bot, conversation, and other metadata
+ */
 export interface ConversationIdObject {
     activityId: string
     user: User


### PR DESCRIPTION
When the channel is msteams the CONVERSATION_ID is set to an object instead of a string.

Somehow we had code that compared the user.id to the conversationId. There must have been a bug previously where Teams client was storing this id in the user object.

They must have fixed their code to store it in the proper conversation object and this updates our code accordingly to match.

Also adds typing information. I made the seeming Microsoft specific properties like `tenantId` and `aadObjectId` nullable for other channel that won't have them.

But I assume all users and bots will have an id and name.