### PR TITLE
fix: use types from BotBuilder

### DIFF
--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -16,7 +16,7 @@ import { CLRecognizerResult } from './CLRecognizeResult'
 import { ConversationLearner } from './ConversationLearner'
 import { InputQueue } from './Memory/InputQueue'
 import * as util from 'util'
-import { UIMode, ConversationIdObject } from './Memory/BotState'
+import { UIMode } from './Memory/BotState'
 
 interface RunnerLookup {
     [appId: string]: CLRunner
@@ -273,7 +273,7 @@ export class CLRunner {
         }
     }
 
-    public async StartSessionAsync(clMemory: CLMemory, conversationId: string | ConversationIdObject | null, appId: string, sessionStartFlags: SessionStartFlags, createParams: CLM.SessionCreateParams | CLM.CreateTeachParams): Promise<CLM.Teach | CLM.Session> {
+    public async StartSessionAsync(clMemory: CLMemory, conversationId: string | BB.ConversationReference | null, appId: string, sessionStartFlags: SessionStartFlags, createParams: CLM.SessionCreateParams | CLM.CreateTeachParams): Promise<CLM.Teach | CLM.Session> {
 
         const inTeach = ((sessionStartFlags & SessionStartFlags.IN_TEACH) > 0)
         let entityList = await this.clClient.GetEntities(appId)

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -14,36 +14,6 @@ export interface ConversationSession {
     conversationId: string | null
 }
 
-/**
- * When using Microsoft Teams the Conversation Id is set to a complex object rather than simple string
- * It contains information about the user, bot, conversation, and other metadata
- */
-export interface ConversationIdObject {
-    activityId: string
-    user: User
-    bot: Bot
-    conversation: Conversation
-    channelId: "msteams" | string
-}
-
-interface User {
-    id: string
-    name: string
-    aadObjectId?: string
-}
-
-interface Bot {
-    id: string
-    name: string
-}
-
-interface Conversation {
-    id: string
-    isGroup?: boolean
-    conversationType: "channel" | "personal" | string
-    tenantId?: string
-}
-
 export interface SessionInfo {
     userName: string,
     userId: string,
@@ -183,11 +153,11 @@ export class BotState {
     // ------------------------------------------------
     //  CONVERSATION_ID
     // ------------------------------------------------
-    public async GetConversationId(): Promise<string | ConversationIdObject | null> {
-        return await this.GetStateAsync<string | ConversationIdObject | null>(BotStateType.CONVERSATION_ID)
+    public async GetConversationId(): Promise<string | BB.ConversationReference | null> {
+        return await this.GetStateAsync<string | BB.ConversationReference | null>(BotStateType.CONVERSATION_ID)
     }
 
-    public async SetConversationId(conversationId: string | ConversationIdObject | null): Promise<void> {
+    public async SetConversationId(conversationId: string | BB.ConversationReference | null): Promise<void> {
         await this.SetStateAsync(BotStateType.CONVERSATION_ID, conversationId)
     }
 
@@ -272,7 +242,7 @@ export class BotState {
         await this.SetStateAsync(BotStateType.SESSION_ID, sessionId)
     }
 
-    public async InitSessionAsync(sessionId: string | null, logDialogId: string | null, conversationId: string | ConversationIdObject | null, sessionStartFlags: SessionStartFlags): Promise<void> {
+    public async InitSessionAsync(sessionId: string | null, logDialogId: string | null, conversationId: string | BB.ConversationReference | null, sessionStartFlags: SessionStartFlags): Promise<void> {
         await this.SetSessionId(sessionId);
         await this.SetLogDialogId(logDialogId)
         await this.SetNeedSessionEndCall(true)


### PR DESCRIPTION
I wasn't aware of types from `botbuilder-js` instead of adding our own.

Talked with Shahin about #459. He had some comments in a review but didn't submit the review so I didn't see them and had already merged thinking it was settled.

There are larger concerns about using conversation references and extracting conversation id string from them instead of storing these ids separately and comparing differently typed objects, but this simple type change is good for start.