### PR TITLE
build: update config to 2.1 for canceling redundant builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -9,24 +9,24 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1-deps-{{ .Branch }}
+            - v1-deps
 
       - run: node --version
       - run: npm --version
       - run: npm ci
 
       - save_cache:
+          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
+            - ~/.npm
+            - ~/.cache
 
       - run: npm run build
       - run: npm run test
       
 workflows:
-  version: 2
   build:
     jobs:
       - build


### PR DESCRIPTION
Similar to https://github.com/microsoft/ConversationLearner-Models/pull/186  

I had only updated the config to 2.1 on the UI and going to do it for models and SDK to leverage auto canceling feature. Also will mke it only build PR's