### PR TITLE
feat: Add added(), removed(), and changes() to memory manager

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,19 +4,13 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "identifier": "build",
+            "label": "build",
             "type": "npm",
             "script": "build",
             "group": {
                 "kind": "build",
                 "isDefault": true
             }
-        },
-        {
-            "identifier": "setpublishversion",
-            "type": "npm",
-            "script": "setpublishversion",
-            "group": "build",
         }
     ]
 }

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -1253,7 +1253,7 @@ export class CLRunner {
                     // Invoke Render part of callback
                     const renderedRenderArgumentValues = this.GetRenderedArguments(callback.renderArguments, apiAction.renderArguments, filledEntityMap)
 
-                    const readOnlyMemoryManager = await this.CreateReadOnlyMemoryManagerAsync(clMemory, allEntities)
+                    const readOnlyMemoryManager = await this.CreateReadOnlyMemoryManagerAsync(clMemory, allEntities, memoryManager.prevMemories)
 
                     let logicObject = logicResult.logicValue ? JSON.parse(logicResult.logicValue) : undefined
                     if (callback.render) {

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -721,7 +721,7 @@ export class CLRunner {
         let sessionInfo = await clMemory.BotState.SessionInfoAsync()
         let curMemories = new CLM.FilledEntityMap(await clMemory.BotMemory.FilledEntityMap());
         if (!prevMemories) {
-            prevMemories = curMemories;
+            prevMemories = new CLM.FilledEntityMap({ map: Utils.deepCopy(curMemories.map) })
         }
         return new ClientMemoryManager(prevMemories, curMemories, allEntities, sessionInfo);
     }
@@ -730,7 +730,7 @@ export class CLRunner {
         let sessionInfo = await clMemory.BotState.SessionInfoAsync()
         let curMemories = new CLM.FilledEntityMap(await clMemory.BotMemory.FilledEntityMap());
         if (!prevMemories) {
-            prevMemories = curMemories;
+            prevMemories = new CLM.FilledEntityMap({ map: Utils.deepCopy(curMemories.map) })
         }
         return new ReadOnlyClientMemoryManager(prevMemories, curMemories, allEntities, sessionInfo);
     }

--- a/src/Memory/ClientMemoryManager.ts
+++ b/src/Memory/ClientMemoryManager.ts
@@ -79,7 +79,7 @@ export class ReadOnlyClientMemoryManager {
      * Categorize each entity as ADDED, REMOVED, CHANGED, or UNCHANGED
      * @param converter Method to transform string text into typed value
      */
-    changed<T = CLM.MemoryValue[] | CLM.MemoryValue>(converter?: (memoryValues: CLM.MemoryValue[]) => T): IChangedMemory<T>[] {
+    changes<T = CLM.MemoryValue[] | CLM.MemoryValue>(converter?: (memoryValues: CLM.MemoryValue[]) => T): IChangedMemory<T>[] {
         return this.allEntities.map<IChangedMemory<T>>(entity => {
             const current = this.Get(entity.entityName)
             const previous = this.GetPrevious(entity.entityName)
@@ -185,12 +185,12 @@ export class ReadOnlyClientMemoryManager {
     }
 
     added() {
-        return this.changed()
+        return this.changes()
             .filter(c => c.changeType === ChangeType.ADDED)
     }
 
     removed() {
-        return this.changed()
+        return this.changes()
             .filter(c => c.changeType === ChangeType.REMOVED)
     }
 

--- a/src/Memory/ClientMemoryManager.ts
+++ b/src/Memory/ClientMemoryManager.ts
@@ -109,23 +109,23 @@ export class ReadOnlyClientMemoryManager {
                         changeType: ChangeType.REMOVED,
                     }
                 }
-                // If both present
-                else if (current && previous) {
+                // If both are not present or both are present and have same userText, consider UNCHANGED
+                else if ((!current && !previous)
+                    || ((current && previous)
+                        && (current.userText === previous.userText))) {
                     // Note: Would need to get raw value and then convert later to avoid comparing after conversion
                     // This could generate new objects which would always show as CHANGED
-                    if (current.userText === previous.userText) {
-                        change = {
-                            name: entity.entityName,
-                            value: current,
-                            changeType: ChangeType.UNCHANGED,
-                        }
+                    change = {
+                        name: entity.entityName,
+                        value: current,
+                        changeType: ChangeType.UNCHANGED,
                     }
-                    else {
-                        change = {
-                            name: entity.entityName,
-                            value: current,
-                            changeType: ChangeType.CHANGED,
-                        }
+                }
+                else {
+                    change = {
+                        name: entity.entityName,
+                        value: current,
+                        changeType: ChangeType.CHANGED,
                     }
                 }
             }
@@ -147,7 +147,7 @@ export class ReadOnlyClientMemoryManager {
                         changeType: ChangeType.REMOVED,
                     }
                 }
-                // If values are same length and userText of each item is the same assume unchanged.
+                // If values are same length (could be empty) and userText of each item is the same assume unchanged.
                 // TODO: Could go further with ITEMS_ADDED, ITEMS_REMOVED, but adds a lot of complexity as you can ADD_ITEMS while also editing items etc.
                 // Otherwise, assume it has changed
                 else if (current.length === previous.length

--- a/src/Memory/clientMemoryManager.test.ts
+++ b/src/Memory/clientMemoryManager.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { FilledEntityMap, EntityBase, EntityType, MemoryValue } from '@conversationlearner/models'
+import { ClientMemoryManager } from '..'
+import { SessionInfo } from './BotState'
+
+describe('ClientMemoryManager', () => {
+    describe('ReadOnlyClientMemoryManager', () => {
+        describe('changed', () => {
+            const baseEntity: EntityBase = {
+                entityId: 'entityBaseId',
+                entityName: 'entityBaseName',
+                entityType: EntityType.LUIS,
+                resolverType: null,
+                createdDateTime: '',
+                version: null,
+                packageCreationId: null,
+                packageDeletionId: null,
+                isMultivalue: false,
+                isNegatible: false,
+                negativeId: null,
+                positiveId: null,
+                doNotMemorize: null
+            }
+
+            const entities: EntityBase[] = [
+                {
+                    ...baseEntity,
+                    entityId: 'entityId1',
+                    entityName: 'entityName1'
+                },
+                {
+                    ...baseEntity,
+                    entityId: 'entityId2',
+                    entityName: 'entityName2'
+                },
+                {
+                    ...baseEntity,
+                    entityId: 'entityId3',
+                    entityName: 'entityName3'
+                },
+                {
+                    ...baseEntity,
+                    entityId: 'entityId4',
+                    entityName: 'entityName4'
+                }
+            ]
+
+            const memoryValueBase: MemoryValue = {
+                userText: "Entity 1 - Single Value String",
+                displayText: "displayText",
+                builtinType: "builtinType",
+                resolution: {},
+                enumValueId: null
+            }
+
+            const previousFilledEntityMap = new FilledEntityMap({
+                map: {
+                    [entities[0].entityName]: {
+                        entityId: entities[0].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 1 - Single Value String"
+                            }
+                        ]
+                    },
+                    [entities[1].entityName]: {
+                        entityId: entities[1].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 2  - Single Value String"
+                            }
+                        ]
+                    },
+                    [entities[2].entityName]: {
+                        entityId: entities[2].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 3 - Multi Value String 1"
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 3 - Multi Value String 2"
+                            }
+                        ]
+                    },
+                    [entities[4].entityName]: {
+                        entityId: entities[4].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "5"
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "5"
+                            }
+                        ]
+                    }
+                }
+            })
+
+            const currentFilledEntityMap = new FilledEntityMap({
+                map: {
+                    'entityName1': {
+                        entityId: 'entityId1',
+                        values: [
+                            {
+                                userText: "userText",
+                                displayText: "displayText",
+                                builtinType: "builtinType",
+                                resolution: {}
+                            }
+                        ]
+                    }
+                }
+            })
+
+
+            const fakeSessionInfo: SessionInfo = {
+                userName: '',
+                userId: '',
+                logDialogId: ''
+            }
+
+            const clientMemoryManager = new ClientMemoryManager(previousFilledEntityMap, currentFilledEntityMap, entities, fakeSessionInfo)
+
+            it('should return the ADDED, REMOVED, CHANGED, and UNCHANGED entities', () => {
+                const changed = clientMemoryManager.changed()
+
+
+            })
+        })
+    })
+})

--- a/src/Memory/clientMemoryManager.test.ts
+++ b/src/Memory/clientMemoryManager.test.ts
@@ -5,6 +5,7 @@
 import { FilledEntityMap, EntityBase, EntityType, MemoryValue } from '@conversationlearner/models'
 import { ClientMemoryManager } from '..'
 import { SessionInfo } from './BotState'
+import { ChangeType } from './ClientMemoryManager';
 
 describe('ClientMemoryManager', () => {
     describe('ReadOnlyClientMemoryManager', () => {
@@ -29,25 +30,62 @@ describe('ClientMemoryManager', () => {
                 {
                     ...baseEntity,
                     entityId: 'entityId1',
-                    entityName: 'entityName1'
+                    entityName: 'entityName1',
                 },
                 {
                     ...baseEntity,
                     entityId: 'entityId2',
-                    entityName: 'entityName2'
+                    entityName: 'entityName2',
                 },
                 {
                     ...baseEntity,
                     entityId: 'entityId3',
-                    entityName: 'entityName3'
+                    entityName: 'entityName3',
                 },
                 {
                     ...baseEntity,
                     entityId: 'entityId4',
-                    entityName: 'entityName4'
-                }
+                    entityName: 'entityName4',
+                },
+                {
+                    ...baseEntity,
+                    isMultivalue: true,
+                    entityId: 'entityId5',
+                    entityName: 'entityName5',
+                },
+                {
+                    ...baseEntity,
+                    isMultivalue: true,
+                    entityId: 'entityId6',
+                    entityName: 'entityName6',
+                },
+                {
+                    ...baseEntity,
+                    isMultivalue: true,
+                    entityId: 'entityId7',
+                    entityName: 'entityName7',
+                },
+                {
+                    ...baseEntity,
+                    isMultivalue: true,
+                    entityId: 'entityId8',
+                    entityName: 'entityName8',
+                },
+                {
+                    ...baseEntity,
+                    isMultivalue: true,
+                    entityId: 'entityId9',
+                    entityName: 'entityName9',
+                },
+                {
+                    ...baseEntity,
+                    isMultivalue: true,
+                    entityId: 'entityId10',
+                    entityName: 'entityName10',
+                },
             ]
 
+            // Do not use directly, use as template and make copies
             const memoryValueBase: MemoryValue = {
                 userText: "Entity 1 - Single Value String",
                 displayText: "displayText",
@@ -56,71 +94,211 @@ describe('ClientMemoryManager', () => {
                 enumValueId: null
             }
 
+            /**
+             * Conditions to create with maps for tests
+             * 
+             * Single Value Changes
+             * Entity 1: Value 1            -> Value 1                  -> Unchanged
+             * Entity 2: Value 1            -> Value 1 Edited           -> Modified
+             * Entity 3: Value 1            ->                          -> Removed
+             * Entity 4:                    -> Value 1                  -> Added
+             *
+             * MultiValue
+             * Entity 5: Value 1            -> Value 1                  -> Unchanged
+             * Entity 6: Value 1            -> Value 1, Value 2         -> Modified (Add Item)
+             * Entity 7: Value 1            -> Value 1 Edited           -> Modified (Edited Item)
+             * Entity 8: Value 1, Value 2   -> Value 1                  -> Modified (Removed Item)
+             * Entity 9: Value 1            ->                          -> Removed
+             * Entity 10:                   -> Value 1, Value 2         -> Added
+             * 
+             * Future Extension:
+             * For more complicated manipulations like adding to multi-value and editing an item, we can assign the entity multiple types, edited - add item
+             */
             const previousFilledEntityMap = new FilledEntityMap({
                 map: {
+                    // Single Values
                     [entities[0].entityName]: {
                         entityId: entities[0].entityId,
                         values: [
                             {
                                 ...memoryValueBase,
-                                userText: "Entity 1 - Single Value String"
-                            }
-                        ]
+                                userText: "Entity 1 - Single Value String",
+                            },
+                        ],
                     },
                     [entities[1].entityName]: {
                         entityId: entities[1].entityId,
                         values: [
                             {
                                 ...memoryValueBase,
-                                userText: "Entity 2  - Single Value String"
-                            }
-                        ]
+                                userText: "Entity 2  - Single Value String",
+                            },
+                        ],
                     },
                     [entities[2].entityName]: {
                         entityId: entities[2].entityId,
                         values: [
                             {
                                 ...memoryValueBase,
-                                userText: "Entity 3 - Multi Value String 1"
+                                userText: "Entity 3 - Single Value String",
                             },
-                            {
-                                ...memoryValueBase,
-                                userText: "Entity 3 - Multi Value String 2"
-                            }
-                        ]
+                        ],
                     },
+
+                    // Multi Value
                     [entities[4].entityName]: {
                         entityId: entities[4].entityId,
                         values: [
                             {
                                 ...memoryValueBase,
-                                userText: "5"
+                                userText: "Entity 5 - Value 1",
                             },
                             {
                                 ...memoryValueBase,
-                                userText: "5"
-                            }
-                        ]
-                    }
+                                userText: "Entity 5 - Value 2",
+                            },
+                        ],
+                    },
+                    [entities[5].entityName]: {
+                        entityId: entities[5].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 6 - Value 1",
+                            },
+                        ],
+                    },
+                    [entities[6].entityName]: {
+                        entityId: entities[6].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 7 - Value 1",
+                            },
+                        ],
+                    },
+                    [entities[7].entityName]: {
+                        entityId: entities[7].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 8 - Value 1",
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 8 - Value 2",
+                            },
+                        ],
+                    },
+                    [entities[8].entityName]: {
+                        entityId: entities[8].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 5 - Value 1",
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 5 - Value 2",
+                            },
+                        ],
+                    },
+                    // 9 Will Be Added
                 }
             })
 
             const currentFilledEntityMap = new FilledEntityMap({
                 map: {
-                    'entityName1': {
-                        entityId: 'entityId1',
+                    [entities[0].entityName]: {
+                        entityId: entities[0].entityId,
                         values: [
                             {
-                                userText: "userText",
-                                displayText: "displayText",
-                                builtinType: "builtinType",
-                                resolution: {}
-                            }
-                        ]
-                    }
+                                ...memoryValueBase,
+                                userText: "Entity 1 - Single Value String",
+                            },
+                        ],
+                    },
+                    [entities[1].entityName]: {
+                        entityId: entities[1].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 2  - Single Value String Edited",
+                            },
+                        ],
+                    },
+                    [entities[3].entityName]: {
+                        entityId: entities[3].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 4 - Single Value String",
+                            },
+                        ],
+                    },
+
+
+                    // Multi Value
+                    [entities[4].entityName]: {
+                        entityId: entities[4].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 5 - Value 1",
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 5 - Value 2",
+                            },
+                        ],
+                    },
+                    [entities[5].entityName]: {
+                        entityId: entities[5].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 6 - Value 1",
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 6 - Value 2",
+                            },
+                        ],
+                    },
+                    [entities[6].entityName]: {
+                        entityId: entities[6].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 7 - Value 1 Edited",
+                            },
+                        ],
+                    },
+                    [entities[7].entityName]: {
+                        entityId: entities[7].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 8 - Value 1",
+                            },
+                        ],
+                    },
+                    // Removed 8
+                    [entities[9].entityName]: {
+                        entityId: entities[9].entityId,
+                        values: [
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 5 - Value 1",
+                            },
+                            {
+                                ...memoryValueBase,
+                                userText: "Entity 5 - Value 2",
+                            },
+                        ],
+                    },
                 }
             })
-
 
             const fakeSessionInfo: SessionInfo = {
                 userName: '',
@@ -131,9 +309,28 @@ describe('ClientMemoryManager', () => {
             const clientMemoryManager = new ClientMemoryManager(previousFilledEntityMap, currentFilledEntityMap, entities, fakeSessionInfo)
 
             it('should return the ADDED, REMOVED, CHANGED, and UNCHANGED entities', () => {
+                // Arrange
+
+                // Act
                 const changed = clientMemoryManager.changed()
 
+                const added = changed.filter(c => c.changeType === ChangeType.ADDED)
+                const removed = changed.filter(c => c.changeType === ChangeType.REMOVED)
+                const modified = changed.filter(c => c.changeType === ChangeType.CHANGED)
+                const unchanged = changed.filter(c => c.changeType === ChangeType.UNCHANGED)
 
+                // Assert
+                expect(unchanged.length).toBe(2)
+                expect(unchanged[0].name).toEqual(entities[0].entityName)
+
+                expect(modified.length).toBe(3)
+                expect(modified[0].name).toEqual(entities[1].entityName)
+
+                expect(added.length).toBe(2)
+                expect(added[0].name).toEqual(entities[3].entityName)
+
+                expect(removed.length).toBe(2)
+                expect(removed[0].name).toEqual(entities[2].entityName)
             })
         })
     })

--- a/src/Memory/clientMemoryManager.test.ts
+++ b/src/Memory/clientMemoryManager.test.ts
@@ -323,7 +323,7 @@ describe('ClientMemoryManager', () => {
                 expect(unchanged.length).toBe(2)
                 expect(unchanged[0].name).toEqual(entities[0].entityName)
 
-                expect(modified.length).toBe(3)
+                expect(modified.length).toBe(4)
                 expect(modified[0].name).toEqual(entities[1].entityName)
 
                 expect(added.length).toBe(2)

--- a/src/Memory/clientMemoryManager.test.ts
+++ b/src/Memory/clientMemoryManager.test.ts
@@ -312,7 +312,7 @@ describe('ClientMemoryManager', () => {
                 // Arrange
 
                 // Act
-                const changed = clientMemoryManager.changed()
+                const changed = clientMemoryManager.changes()
 
                 const added = changed.filter(c => c.changeType === ChangeType.ADDED)
                 const removed = changed.filter(c => c.changeType === ChangeType.REMOVED)

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -204,4 +204,38 @@ export const isRunningInClUI: (context: BB.TurnContext) => boolean = (context) =
     return context && context.activity && context.activity && context.activity.from && context.activity.from.name === CL_DEVELOPER
 }
 
+export function deepCopy<T>(obj: T): T {
+    let copy: any;
 
+    // Simple types, null or undefined
+    if (obj === null || typeof obj !== "object") {
+        return obj
+    }
+
+    // Date
+    if (obj instanceof Date) {
+        copy = new Date();
+        copy.setTime(obj.getTime());
+        return copy as T;
+    }
+
+    // Array
+    if (obj instanceof Array) {
+        copy = [];
+        obj.forEach((item, index) => copy[index] = deepCopy(obj[index]))
+        return copy as T;
+    }
+
+    // Handle Object
+    if (obj instanceof Object) {
+        copy = {};
+        Object.keys(obj).forEach(attr => {
+            if ((obj as Object).hasOwnProperty(attr)) {
+                copy[attr] = deepCopy(obj[attr])
+            }
+        })
+        return copy as T;
+    }
+
+    throw new Error("Unknown Type");
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -219,6 +219,7 @@ export const isRunningInClUI: (context: BB.TurnContext) => boolean = (context) =
     return context && context.activity && context.activity && context.activity.from && context.activity.from.name === CL_DEVELOPER
 }
 
+// Copied from UI repo. Could swap for library if there is case this doesn't cover, although prefer to not take dependency.
 export function deepCopy<T>(obj: T): T {
     let copy: any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  */
 import { ConversationLearner } from './ConversationLearner'
 import { ICLOptions } from './CLOptions'
-import { ClientMemoryManager, ReadOnlyClientMemoryManager } from './Memory/ClientMemoryManager'
+import { ClientMemoryManager, ReadOnlyClientMemoryManager, ChangeType } from './Memory/ClientMemoryManager'
 import { RedisStorage } from './RedisStorage'
 import { FileStorage } from './FileStorage'
 import uiRouter from './uiRouter'
@@ -13,6 +13,7 @@ import { EntityDetectionCallback, OnSessionStartCallback, OnSessionEndCallback, 
 
 export {
     uiRouter,
+    ChangeType,
     ConversationLearner,
     ICLOptions,
     ClientMemoryManager,


### PR DESCRIPTION
`added()` and `removed()` are derived from the `changes()`.

Changes returns change objects indicating type of change (ADDED, REMOVED, CHANGED, ...) extensible for more types such as ITEM_ADDED, ITEM_REMOVED although those are openning up complexity to calculate. 

`added()` and `removed()` only return those changes. The objects include the entity name instead of just the MemoryValue so the user knows which entity was added or removed.

Also fixes bug with `Set` affecting both previous and current memory maps since they were copies. Took a long time to understand the error was in memory manager instead of my code.

Fixes: ADO#1861