### PR TITLE
fix: bug 2181 dubug messages leaking to wrong conversation

### DIFF
--- a/src/CLDebug.ts
+++ b/src/CLDebug.ts
@@ -34,6 +34,12 @@ export class CLDebug {
 
     public static InitLogger(adapter: BB.BotAdapter, conversationReference: Partial<BB.ConversationReference>) {
         CLDebug.adapter = adapter
+
+        // Clear cache if conversation changed
+        // TODO: cache by conversationReference
+        if (CLDebug.conversationReference !== conversationReference) {
+            CLDebug.cachedMessages = []
+        }
         CLDebug.conversationReference = conversationReference;
     }
 

--- a/src/CLDebug.ts
+++ b/src/CLDebug.ts
@@ -35,8 +35,9 @@ export class CLDebug {
     public static InitLogger(adapter: BB.BotAdapter, conversationReference: Partial<BB.ConversationReference>) {
         CLDebug.adapter = adapter
 
-        // Clear cache if conversation changed
-        // TODO: cache by conversationReference
+        // Clear cache if conversation changed 
+        // Note: Could result in very rare loss of debug message triggered 
+        // at start of new conversation
         if (CLDebug.conversationReference !== conversationReference) {
             CLDebug.cachedMessages = []
         }


### PR DESCRIPTION
The cache is in place to cover logs/errors that are triggered before the adpater is set (i.e. a brand new conversation).  Now it checks that the same conversationReference is set, so messages don't leak from one conversation to another.  However, this means that there's a rare case where an error message at conversation start could never get sent.  