### PR TITLE
 feat: enable dispatching to sub models

### DIFF
--- a/src/CLDebug.ts
+++ b/src/CLDebug.ts
@@ -11,7 +11,8 @@ export enum DebugType {
     ClientBody = 1 << 1,
     MessageQueue = 1 << 2,
     Memory = 1 << 3,
-    MemVerbose = 1 << 4
+    MemVerbose = 1 << 4,
+    Dispatch = 1 << 5,
 }
 
 enum LogType {

--- a/src/CLMemory.ts
+++ b/src/CLMemory.ts
@@ -8,9 +8,20 @@ import * as Utils from './Utils'
 import { CLDebug, DebugType } from './CLDebug'
 import { BotMemory } from './Memory/BotMemory'
 import { BotState } from './Memory/BotState'
+import InProcessMessageState from './Memory/InProcessMessageState'
 
+/**
+ * This outer instance of CLMemory has keyPrefix specific to model + conversation.
+ * This was required for dispatching when multiple models needed separate state for the same conversation.
+ * 
+ * The inner conversationStorage instance of CLMemory has keyPrefix mapped to the conversation.
+ * This enabled tracking message state within the conversation independently of how many models are used within the conversation.
+ */
 export class CLMemory {
     private static memoryStorage: BB.Storage | null = null
+    // TODO: Remove later, after refactor to change hierarchy to State -> ClStorage -> BB.Storage
+    private conversationStorage: CLMemory | undefined
+
     private memCache = {}
     private keyPrefix: string
     private turnContext: BB.TurnContext | null
@@ -30,7 +41,9 @@ export class CLMemory {
     }
 
     public static GetMemory(key: string): CLMemory {
-        return new CLMemory(key)
+        const memory = new CLMemory(key)
+        memory.conversationStorage = new CLMemory(key)
+        return memory
     }
 
     // Generate memory key from session
@@ -39,6 +52,7 @@ export class CLMemory {
         const user = conversationReference.user
 
         let keyPrefix: string | null = null
+        let messageMutexPrefix: string
         if (Utils.isRunningInClUI(turnContext)) {
             if (!user) {
                 throw new Error(`Attempted to initialize memory, but cannot get memory key because current request did not have 'from'/user specified`)
@@ -46,18 +60,23 @@ export class CLMemory {
             if (!user.id) {
                 throw new Error(`Attempted to initialize memory, but user.id was not provided which is required for use as memory key.`)
             }
-            // User ID is the browser slot assinged to the UI
+            // User ID is the browser slot assigned to the UI
             keyPrefix = `${modelId}${user.id}`
+            messageMutexPrefix = user.id
         } else {
             // Memory uses conversation Id as the prefix key for all the objects kept in CLMemory when bot is not running against CL UI
             if (!conversationReference.conversation || !conversationReference.conversation.id) {
                 throw new Error(`Attempted to initialize memory, but conversationReference.conversation.id was not provided which is required for use as memory key.`)
             }
-            // Dispatcher submodels will have the same converstaion id thus we need the model id to differentiate
+            // Dispatcher subModels will have the same converataion id thus we need the model id to differentiate
             keyPrefix = `${modelId}${conversationReference.conversation.id}`
+            messageMutexPrefix = conversationReference.conversation.id
         }
 
-        return new CLMemory(keyPrefix, turnContext)
+        const modelStorage = new CLMemory(keyPrefix, turnContext)
+        const conversationStorage = new CLMemory(messageMutexPrefix, turnContext)
+        modelStorage.conversationStorage = conversationStorage
+        return modelStorage
     }
 
     private Key(datakey: string): string {
@@ -153,6 +172,14 @@ export class CLMemory {
 
     public get BotState(): BotState {
         return BotState.Get(this, this.turnContext ? BB.TurnContext.getConversationReference(this.turnContext.activity) : null)
+    }
+
+    public get MessageState(): InProcessMessageState {
+        if (!this.conversationStorage) {
+            throw new Error(`conversationStorage must be set in order to get MessageState`)
+        }
+
+        return InProcessMessageState.Get(this.conversationStorage)
     }
 
     public get TurnContext(): BB.TurnContext | null {

--- a/src/CLMemory.ts
+++ b/src/CLMemory.ts
@@ -34,7 +34,7 @@ export class CLMemory {
     }
 
     // Generate memory key from session
-    public static async InitMemory(turnContext: BB.TurnContext): Promise<CLMemory> {
+    public static async InitMemory(turnContext: BB.TurnContext, modelId: string = ''): Promise<CLMemory> {
         const conversationReference = BB.TurnContext.getConversationReference(turnContext.activity)
         const user = conversationReference.user
 
@@ -46,13 +46,15 @@ export class CLMemory {
             if (!user.id) {
                 throw new Error(`Attempted to initialize memory, but user.id was not provided which is required for use as memory key.`)
             }
-            keyPrefix = user.id
+            // User ID is the browser slot assinged to the UI
+            keyPrefix = `${modelId}${user.id}`
         } else {
             // Memory uses conversation Id as the prefix key for all the objects kept in CLMemory when bot is not running against CL UI
             if (!conversationReference.conversation || !conversationReference.conversation.id) {
                 throw new Error(`Attempted to initialize memory, but conversationReference.conversation.id was not provided which is required for use as memory key.`)
             }
-            keyPrefix = conversationReference.conversation.id
+            // Dispatcher submodels will have the same converstaion id thus we need the model id to differentiate
+            keyPrefix = `${modelId}${conversationReference.conversation.id}`
         }
 
         return new CLMemory(keyPrefix, turnContext)

--- a/src/CLMemory.ts
+++ b/src/CLMemory.ts
@@ -159,6 +159,7 @@ export class CLMemory {
     public async SetAppAsync(app: CLM.AppBase | null): Promise<void> {
         const curApp = await this.BotState.GetApp();
         await this.BotState._SetAppAsync(app)
+        await this.MessageState.remove()
 
         if (!app || !curApp || curApp.appId !== app.appId) {
             await this.BotMemory.ClearAsync()

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -315,6 +315,7 @@ export class CLRunner {
 
         // Initialize Bot State
         await clMemory.BotState.InitSessionAsync(sessionId, logDialogId, conversationRef, sessionStartFlags)
+        await clMemory.MessageState.remove()
 
         CLDebug.Verbose(`Started Session: ${sessionId} - ${clMemory.BotState.GetConversationId()}`)
         return startResponse
@@ -354,6 +355,7 @@ export class CLRunner {
             await this.CheckSessionEndCallback(memory, entityList.entities, sessionEndState, data);
 
             await memory.BotState.EndSessionAsync();
+            await memory.MessageState.remove()
         }
     }
 

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -1323,14 +1323,7 @@ export class CLRunner {
     }
 
     public async TakeTextAction(textAction: CLM.TextAction, filledEntityMap: CLM.FilledEntityMap): Promise<Partial<BB.Activity> | string> {
-        const actionString = textAction.renderValue(CLM.getEntityDisplayValueMap(filledEntityMap))
-
-        if (actionString.startsWith('@DISPATCH')) {
-            const [, modelId,] = actionString.split(':')
-            console.log(`TakeTextAction: Dispatch to model: ${modelId}`)
-        }
-
-        return Promise.resolve(actionString)
+        return Promise.resolve(textAction.renderValue(CLM.getEntityDisplayValueMap(filledEntityMap)))
     }
 
     public async TakeCardAction(cardAction: CLM.CardAction, filledEntityMap: CLM.FilledEntityMap): Promise<Partial<BB.Activity> | string> {

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -8,7 +8,7 @@ import * as CLM from '@conversationlearner/models'
 import * as Utils from './Utils'
 import { CLMemory } from './CLMemory'
 import { BotMemory } from './Memory/BotMemory'
-import { CLDebug } from './CLDebug'
+import { CLDebug, DebugType } from './CLDebug'
 import { CLClient } from './CLClient'
 import { CLStrings } from './CLStrings'
 import { TemplateProvider } from './TemplateProvider'
@@ -511,12 +511,12 @@ export class CLRunner {
             // TODO: Use new action type and check type instead of text prefix
             const dispatchActionPrefix = '@DISPATCH'
             if (scoredAction.payload.includes(dispatchActionPrefix)) {
-                console.log(`DISPATCH action detected in model ${this.configModelId}.`)
+                CLDebug.Log(`DISPATCH action detected in model ${this.configModelId}.`, DebugType.Dispatch)
                 // Get child model id and name from action
                 const matches = scoredAction.payload.match(new RegExp(`${dispatchActionPrefix}:([^:]+):([^"]+)`, 'i'))
                 if (matches) {
                     const [, modelId, modelName] = matches
-                    console.log(`Dispatch to Model: ${modelId} ${modelName}`)
+                    CLDebug.Log(`Dispatch to Model: ${modelId} ${modelName}`, DebugType.Dispatch)
 
                     // Get CL model
                     // if it does not exist as child of this instance, then create it and add it.

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -17,7 +17,6 @@ import { CLRecognizerResult } from './CLRecognizeResult'
 import { ConversationLearner } from './ConversationLearner'
 import { InputQueue } from './Memory/InputQueue'
 import { UIMode } from './Memory/BotState';
-import InProcessMessageState from './Memory/InProcessMessageState';
 
 interface RunnerLookup {
     [appId: string]: CLRunner

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -508,10 +508,11 @@ export class CLRunner {
             )
 
             // TODO: Use new action type and check type instead of text prefix
-            if (scoredAction.payload.includes('@DISPATCH')) {
-                console.log(`DISPATCH action detected. ProcessInput of model: ${this.configModelId}.`)
+            const dispatchActionPrefix = '@DISPATCH'
+            if (scoredAction.payload.includes(dispatchActionPrefix)) {
+                console.log(`DISPATCH action detected in model ${this.configModelId}.`)
                 // Get child model id and name from action
-                const matches = scoredAction.payload.match(/@DISPATCH:([^:]+):([^"]+)/i)
+                const matches = scoredAction.payload.match(new RegExp(`${dispatchActionPrefix}:([^:]+):([^"]+)`, 'i'))
                 if (matches) {
                     const [, modelId, modelName] = matches
                     console.log(`Dispatch to Model: ${modelId} ${modelName}`)

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -6,8 +6,7 @@ import * as BB from 'botbuilder'
 import { ConversationLearner } from '../ConversationLearner'
 import { CLMemory } from '../CLMemory'
 import { AppBase } from '@conversationlearner/models'
-import { QueuedInput } from './InputQueue';
-import { SessionStartFlags } from '../CLRunner';
+import { SessionStartFlags } from '../CLRunner'
 
 export interface ConversationSession {
     sessionId: string | null
@@ -118,7 +117,6 @@ export class BotState {
         await this.SetApp(app)
         await this.SetConversationReference(null)
         await this.SetLastActive(0);
-        await this.SetMessageProcessing(null);
         await this.SetNeedSessionEndCall(false)
         await this.SetUIMode(UIMode.NONE)
         await this.SetSessionId(null)
@@ -247,7 +245,6 @@ export class BotState {
         await this.SetConversationReference(conversationReference)
         await this.SetLastActive(new Date().getTime())
         await this.SetUIMode(uiMode)
-        await this.SetMessageProcessing(null)
     }
 
     // End a session.
@@ -257,7 +254,6 @@ export class BotState {
         await this.SetConversationReference(null)
         await this.SetLastActive(0);
         await this.SetUIMode(UIMode.NONE);
-        await this.SetMessageProcessing(null);
     }
 
     // ------------------------------------------------
@@ -309,23 +305,6 @@ export class BotState {
 
     public async SetLogDialogId(logDialogId: string | null): Promise<void> {
         await this.SetStateAsync(BotStateType.LOG_DIALOG_ID, logDialogId)
-    }
-
-    // ------------------------------------------------
-    //  MESSAGE_MUTEX
-    // ------------------------------------------------
-    public async GetMessageProcessing(): Promise<QueuedInput | null> {
-        return await this.GetStateAsync<QueuedInput>(BotStateType.MESSAGE_MUTEX)
-    }
-
-    public async MessageProcessingPopAsync(): Promise<QueuedInput | null> {
-        let popVal = await this.GetStateAsync<QueuedInput>(BotStateType.MESSAGE_MUTEX)
-        await this.SetStateAsync(BotStateType.MESSAGE_MUTEX, null);
-        return popVal;
-    }
-
-    public async SetMessageProcessing(queuedInput: QueuedInput | null): Promise<void> {
-        await this.SetStateAsync(BotStateType.MESSAGE_MUTEX, queuedInput)
     }
 
     // -------------------------------------------------------------------

--- a/src/Memory/InProcessMessageState.ts
+++ b/src/Memory/InProcessMessageState.ts
@@ -7,6 +7,10 @@ import { CLMemory } from '../CLMemory'
 // Current message being processed
 const MESSAGE_MUTEX = 'MESSAGE_MUTEX'
 
+/**
+ * Tracks the state of messages which are being processed.
+ * The memory instances given to this class should be associated with lifetime of messages, eg the conversation
+ */
 export default class InProcessMessageState {
     private static _instance: InProcessMessageState | undefined
 

--- a/src/Memory/InProcessMessageState.ts
+++ b/src/Memory/InProcessMessageState.ts
@@ -20,7 +20,7 @@ export default class InProcessMessageState {
 
     private clStorage: CLMemory
 
-    constructor(clStorage: CLMemory) {
+    private constructor(clStorage: CLMemory) {
         this.clStorage = clStorage
     }
 

--- a/src/Memory/InProcessMessageState.ts
+++ b/src/Memory/InProcessMessageState.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { CLMemory } from '../CLMemory'
+
+// Current message being processed
+const MESSAGE_MUTEX = 'MESSAGE_MUTEX'
+
+export default class InProcessMessageState {
+    private static _instance: InProcessMessageState | undefined
+
+    public static Get(clMemory: CLMemory): InProcessMessageState {
+        if (!InProcessMessageState._instance) {
+            InProcessMessageState._instance = new InProcessMessageState(clMemory)
+        }
+
+        return InProcessMessageState._instance
+    }
+
+    private clStorage: CLMemory
+
+    constructor(clStorage: CLMemory) {
+        this.clStorage = clStorage
+    }
+
+    async get<T>(): Promise<T> {
+        return await this.getStateAsync<T>()
+    }
+
+    async remove<T>(): Promise<T> {
+        let currentValue = await this.getStateAsync<T>()
+        await this.setStateAsync(null);
+        return currentValue;
+    }
+
+    async set<T>(message: T | null): Promise<void> {
+        await this.setStateAsync(message)
+    }
+
+    private async getStateAsync<T>(): Promise<T> {
+        try {
+            let data = await this.clStorage.GetAsync(MESSAGE_MUTEX);
+            return JSON.parse(data) as T;
+        }
+        catch {
+            // If brand new use, need to initialize
+            await this.set(null);
+            const data = await this.clStorage.GetAsync(MESSAGE_MUTEX)
+            return JSON.parse(data) as T;
+        }
+    }
+
+    private async setStateAsync<T>(value: T): Promise<void> {
+        const json = JSON.stringify(value)
+        await this.clStorage.SetAsync(MESSAGE_MUTEX, json)
+    }
+}


### PR DESCRIPTION
This is minimal change to get dispatch actually working in the logs so it can be tested. After a few debug sessions with Lars we have more changes planned.

When in training the bot returns the action the dispatcher model takes which is (What model to dispatch to?)
When in logs the bot recursively delegates to the subModels until an action on one of the leaf model is reached and this is returned.

Usages depends on generation of model/actions using UI feature. It currently generates text actions with special encoding to indicate they are dispatch actions but should introduce new action type in future.

Technical Changes:
- Detection of Dispatch action (Encoding of text actions)
- Splitting out the MessageState tracking from BotState to allow independent CLMemory intances with different keys. We needed the BotState, BotMemory to be specific to the dispatch models of the conversation, but we needed the message state tracking for each of these models shared since all messages are for the same conversation.

More changes to come.