### PR TITLE
 feat: change Init() to Factory patterns to avoid temporal coupling

### DIFF
--- a/src/CLOptions.ts
+++ b/src/CLOptions.ts
@@ -2,17 +2,10 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-export interface ICLOptions {
+import { ICLClientOptions } from './CLClient'
+
+export interface ICLOptions extends ICLClientOptions {
     botPort: any
-
-    LUIS_AUTHORING_KEY: string | undefined
-    LUIS_SUBSCRIPTION_KEY: string | undefined
-    APIM_SUBSCRIPTION_KEY: string | undefined
-
-    // URL for Conversation Learner service
-    CONVERSATION_LEARNER_SERVICE_URI: string
-    CONVERSATION_LEARNER_UI_PORT: number
-
-    // Application settings
-    SESSION_MAX_TIMEOUT?: number
 }
+
+

--- a/src/ConversationLearnerFactory.ts
+++ b/src/ConversationLearnerFactory.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as BB from 'botbuilder'
+import { ConversationLearner } from './ConversationLearner'
+import { ICLOptions, CLClient } from '.'
+import getRouter from './http/router'
+import * as express from 'express'
+import CLStateFactory from './Memory/CLStateFactory';
+
+/**
+ * Conversation Learner Factory. Produces instances that all use the same storage, client, and options.
+ * Alternative which ConversationLearner.Init() which set the statics but this created temporal coupling (need to call Init before constructor)
+ */
+export default class ConversationLearnerFactory {
+    private storageFactory: CLStateFactory
+    private client: CLClient
+    private options: ICLOptions
+    sdkRouter: express.Router
+
+    constructor(options: ICLOptions, bbStorage: BB.Storage = new BB.MemoryStorage()) {
+        this.storageFactory = new CLStateFactory(bbStorage)
+        this.options = options
+
+        const client = new CLClient(options)
+        this.client = client
+
+        this.sdkRouter = getRouter(client, this.storageFactory, options)
+    }
+
+    create(modelId?: string) {
+        return new ConversationLearner(this.storageFactory, this.client, this.options, modelId)
+    }
+}

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 import * as BB from 'botbuilder'
-import { ConversationLearner } from '../ConversationLearner'
 import { CLStorage } from './CLStorage'
 import { AppBase } from '@conversationlearner/models'
 import { SessionStartFlags } from '../CLRunner'
@@ -69,7 +68,11 @@ export class BotState {
     private readonly getKey: GetKey
     private readonly conversationReferenceToConversationIdMapper: ConvIdMapper
 
-    constructor(storage: CLStorage, getKey: GetKey, conversationReferenceToConvIdMapper: ConvIdMapper = BotState.DefaultConversationIdMapper) {
+    constructor(
+        storage: CLStorage,
+        getKey: GetKey,
+        conversationReferenceToConvIdMapper: ConvIdMapper = BotState.DefaultConversationIdMapper
+    ) {
         this.storage = storage
         this.getKey = getKey
         this.conversationReferenceToConversationIdMapper = conversationReferenceToConvIdMapper
@@ -274,7 +277,7 @@ export class BotState {
             channelId: 'emulator',
             // TODO: Refactor away from static coupling.  BotState needs to have access to options object through constructor
             // tslint:disable-next-line:no-http-string
-            serviceUrl: `http://127.0.0.1:${ConversationLearner.options!.botPort}`
+            serviceUrl: `http://127.0.0.1:${3978}`
         } as Partial<BB.ConversationReference>
         this.SetConversationReference(conversationReference)
     }

--- a/src/Memory/CLState.ts
+++ b/src/Memory/CLState.ts
@@ -4,12 +4,9 @@
  */
 import * as BB from 'botbuilder'
 import * as CLM from '@conversationlearner/models'
-import * as Utils from '../Utils'
-import { CLDebug } from '../CLDebug'
 import { EntityState } from './EntityState'
 import { BotState } from './BotState'
 import { InProcessMessageState as MessageState } from './InProcessMessageState'
-import { CLStorage } from './CLStorage';
 import { BrowserSlotState } from './BrowserSlot';
 
 /**
@@ -25,7 +22,6 @@ import { BrowserSlotState } from './BrowserSlot';
  *   - Example: SetApp (which affects BotState, EntityState, and MessageState)
  */
 export class CLState {
-    private static bbStorage: BB.Storage
     public readonly turnContext?: BB.TurnContext
 
     BotState: BotState
@@ -33,7 +29,7 @@ export class CLState {
     MessageState: MessageState
     BrowserSlotState: BrowserSlotState
 
-    private constructor(
+    constructor(
         botState: BotState,
         entityState: EntityState,
         messageState: MessageState,
@@ -46,57 +42,6 @@ export class CLState {
         this.BrowserSlotState = browserSlotState
 
         this.turnContext = turnContext
-    }
-
-    public static Init(storage?: BB.Storage): void {
-        // If memory storage not defined use disk storage
-        if (!storage) {
-            CLDebug.Log('Storage not defined.  Defaulting to in-memory storage.')
-            storage = new BB.MemoryStorage()
-        }
-
-        CLState.bbStorage = storage
-    }
-
-    public static Get(key: string, modelId: string = ''): CLState {
-        const storage = new CLStorage(CLState.bbStorage)
-
-        // Used for state shared through lifetime of conversation (conversationId)
-        const keyPrefix = Utils.getSha256Hash(key)
-        // Used for state shared between models within a conversation (Dispatcher has multiple models per conversation)
-        const modelUniqueKeyPrefix = Utils.getSha256Hash(`${modelId}${key}`)
-
-        const botState = new BotState(storage, (datakey) => `${modelUniqueKeyPrefix}_BOTSTATE_${datakey}`)
-        const entityState = new EntityState(storage, () => `${modelUniqueKeyPrefix}_ENTITYSTATE`)
-        const messageState = new MessageState(storage, () => `${keyPrefix}_MESSAGE_MUTEX`)
-        const browserSlotState = new BrowserSlotState(storage, () => `BROWSER_SLOTS`)
-
-        return new CLState(botState, entityState, messageState, browserSlotState)
-    }
-
-    public static GetFromContext(turnContext: BB.TurnContext, modelId: string = ''): CLState {
-        const conversationReference = BB.TurnContext.getConversationReference(turnContext.activity)
-        const user = conversationReference.user
-
-        let keyPrefix: string
-        if (Utils.isRunningInClUI(turnContext)) {
-            if (!user) {
-                throw new Error(`Attempted to initialize state, but cannot get state key because current request did not have 'from'/user specified`)
-            }
-            if (!user.id) {
-                throw new Error(`Attempted to initialize state, but user.id was not provided which is required for use as state key.`)
-            }
-            // User ID is the browser slot assigned to the UI
-            keyPrefix = user.id
-        } else {
-            // CLState uses conversation Id as the prefix key for all the objects kept in CLStorage when bot is not running against CL UI
-            if (!conversationReference.conversation || !conversationReference.conversation.id) {
-                throw new Error(`Attempted to initialize state, but conversationReference.conversation.id was not provided which is required for use as state key.`)
-            }
-            keyPrefix = conversationReference.conversation.id
-        }
-
-        return CLState.Get(keyPrefix, modelId)
     }
 
     public async SetAppAsync(app: CLM.AppBase | null): Promise<void> {

--- a/src/Memory/CLStateFactory.ts
+++ b/src/Memory/CLStateFactory.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as BB from 'botbuilder'
+import { CLStorage } from './CLStorage'
+import { CLState } from './CLState'
+import * as Utils from '../Utils'
+import { BotState } from './BotState';
+import { EntityState } from './EntityState';
+import { InProcessMessageState as MessageState } from './InProcessMessageState';
+import { BrowserSlotState } from './BrowserSlot';
+
+/**
+ * Conversation Learner State Factory. 
+ * 
+ * Produces instances that all use the same BotBuilder storage provider.
+ */
+export class CLStateFactory {
+    private bbStorage: BB.Storage
+
+    constructor(bbStorage: BB.Storage = new BB.MemoryStorage()) {
+        this.bbStorage = bbStorage
+    }
+
+    get(key: string, modelId: string = ''): CLState {
+        const storage = new CLStorage(this.bbStorage)
+
+        // Used for state shared through lifetime of conversation (conversationId)
+        const keyPrefix = Utils.getSha256Hash(key)
+        // Used for state shared between models within a conversation (Dispatcher has multiple models per conversation)
+        const modelUniqueKeyPrefix = Utils.getSha256Hash(`${modelId}${key}`)
+
+        const botState = new BotState(storage, (datakey) => `${modelUniqueKeyPrefix}_BOTSTATE_${datakey}`)
+        const entityState = new EntityState(storage, () => `${modelUniqueKeyPrefix}_ENTITYSTATE`)
+        const messageState = new MessageState(storage, () => `${keyPrefix}_MESSAGE_MUTEX`)
+        const browserSlotState = new BrowserSlotState(storage, () => `BROWSER_SLOTS`)
+
+        return new CLState(botState, entityState, messageState, browserSlotState)
+    }
+
+    getFromContext(turnContext: BB.TurnContext, modelId: string = ''): CLState {
+        const conversationReference = BB.TurnContext.getConversationReference(turnContext.activity)
+        const user = conversationReference.user
+
+        let keyPrefix: string
+        if (Utils.isRunningInClUI(turnContext)) {
+            if (!user) {
+                throw new Error(`Attempted to initialize state, but cannot get state key because current request did not have 'from'/user specified`)
+            }
+            if (!user.id) {
+                throw new Error(`Attempted to initialize state, but user.id was not provided which is required for use as state key.`)
+            }
+            // User ID is the browser slot assigned to the UI
+            keyPrefix = user.id
+        } else {
+            // CLState uses conversation Id as the prefix key for all the objects kept in CLStorage when bot is not running against CL UI
+            if (!conversationReference.conversation || !conversationReference.conversation.id) {
+                throw new Error(`Attempted to initialize state, but conversationReference.conversation.id was not provided which is required for use as state key.`)
+            }
+            keyPrefix = conversationReference.conversation.id
+        }
+
+        return this.get(keyPrefix, modelId)
+    }
+}
+
+export default CLStateFactory

--- a/src/http/router.test.ts
+++ b/src/http/router.test.ts
@@ -5,7 +5,9 @@
 import * as supertest from 'supertest'
 import * as express from 'express'
 import router from './router'
-import { ICLClientOptions, CLClient } from '../CLClient'
+import { ICLClientOptions } from '../CLClient'
+import { CLClient } from '..';
+import CLStateFactory from '../Memory/CLStateFactory';
 
 describe('Test SDK router', () => {
     const options: ICLClientOptions = {
@@ -13,8 +15,10 @@ describe('Test SDK router', () => {
         APIM_SUBSCRIPTION_KEY: undefined,
         LUIS_AUTHORING_KEY: undefined
     }
-    const clClient = new CLClient(options)
-    const sdkRouter = router(clClient, options)
+
+    const client = new CLClient(options)
+    const stateFactory = new CLStateFactory()
+    const sdkRouter = router(client, stateFactory, options)
     const app = express()
     app.use(sdkRouter)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,22 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ConversationLearner } from './ConversationLearner'
+import ConversationLearnerFactory from './ConversationLearnerFactory'
 import { ICLOptions } from './CLOptions'
 import { ClientMemoryManager, ReadOnlyClientMemoryManager } from './Memory/ClientMemoryManager'
 import { RedisStorage } from './RedisStorage'
 import { FileStorage } from './FileStorage'
 import uiRouter from './uiRouter'
+import { CLClient } from './CLClient'
+import { getRouter as getSdkRouter } from './http/router'
 import { SessionEndState, MemoryValue } from '@conversationlearner/models'
 import { EntityDetectionCallback, OnSessionStartCallback, OnSessionEndCallback, LogicCallback, RenderCallback, ICallbackInput } from './CLRunner'
 
 export {
+    CLClient,
     uiRouter,
-    ConversationLearner,
+    getSdkRouter,
+    ConversationLearnerFactory,
     ICLOptions,
     ClientMemoryManager,
     ReadOnlyClientMemoryManager,


### PR DESCRIPTION
Uses Factory pattern to ensure instances are created with consistent properties instead setting shared statics across the instances from `Init()`.

#### Before:
you could create instances of sub objects and then later get a runtime error when a static requirement was not set. This is the temporal coupling that `Init()` must have been called first.

#### After:
It's not possible to construct or use instances incorrectly. In order to create an instance you must create a factory. In order to create a factory you must provide the arguments which were the shared statics before.

### Example of what this would do to the Samples repo:

#### Before:
```
const sdkRouter = ConversationLearner.Init(clOptions, redisStorage)

let cl = new ConversationLearner(modelId);
```

#### After:
```
const clFactory = new ConversationLearnerFactory(clOptions, fileStorage)

let cl = clFactory.create(modelId);
```
 
This is compared with the pending hierarchy fix PR and still deciding on this change, but wanted to propose it to get feedback

### SdkRouter

It was always awkward that the `Init()` function returned a router, and that side affet is stilll preset as `sdkRouter` is a property on the factory.

### Questions
Still thinking about the complexity trade off. I like that it follow more common patterns that would know, and that it enforces correct usage but I would be interested in using plain javascript objects instead of the Classes with static properties.  This could also be much simpler as everything being a singleton instead of most things being instances.