### PR TITLE
feat: use DISPATCH action type instead of overloaded TEXT action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -413,14 +413,14 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.206.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.206.0.tgz",
-      "integrity": "sha512-YRYfEXJ52J+/1bZ+Bf5zjWEjXQIkoPu0TOLESedWihs7mWE9yxT8Uu6GYRo3Rs2ul1cdg+QPQNn3gVrpwHxLSQ=="
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.207.0.tgz",
+      "integrity": "sha512-TlanI0ROOR/gPV0GLOTFv5iro77CZG/yLTFUbc2MFPYARjNjZl1qEVOuNRQqvmoRkexcqu3NUpMOXC06WOHhew=="
     },
     "@conversationlearner/ui": {
-      "version": "0.377.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.377.0.tgz",
-      "integrity": "sha512-TyRSCZyod8ReB6N3Cf+JI9CthMXl/7YS1KEe4qTWNfCP6fipc4qKaD1/6U7PfT/RANNIlZcZoooB/EDdV5R1gg=="
+      "version": "0.378.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.378.0.tgz",
+      "integrity": "sha512-C/yaU8JiNpS32MmJZPpDafJ9KmkaGXX2TTeHgS7k5hZ9Sj4JZvrGFOMAlfMeQnf+mg6M/Rqlo/unlDwz/ASepQ=="
     },
     "@jest/console": {
       "version": "24.3.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "author": "Microsoft Conversation Learner Team",
   "license": "MIT",
   "dependencies": {
-    "@conversationlearner/models": "0.206.0",
-    "@conversationlearner/ui": "0.377.0",
+    "@conversationlearner/models": "0.207.0",
+    "@conversationlearner/ui": "0.378.0",
     "@types/supertest": "2.0.4",
     "async-file": "^2.0.2",
     "body-parser": "1.18.3",


### PR DESCRIPTION
depends on UI generating these actions since they can't be manually created or edited.

Updates the `GetHistory` function to return the card placeholders similar to the SET_ENTITY actions.

## ActionDetailsList
![image](https://user-images.githubusercontent.com/2856501/62739161-0e4da980-b9e9-11e9-8095-0eafc4d777b2.png)

## ActionCreatorEditor
![image](https://user-images.githubusercontent.com/2856501/62739198-186fa800-b9e9-11e9-8804-020ac5010aa4.png)

## Card Placeholder in Train Dialogs:
![image](https://user-images.githubusercontent.com/2856501/62739210-258c9700-b9e9-11e9-88a6-b5e54419ee99.png)
