### PR TITLE
feat: make EDC assignment instead of function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
     "workbench.colorCustomizations": {
         "activityBar.background": "#5a0656"
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "docs/**/*": true,
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6362,7 +6362,8 @@
         },
         "lodash": {
           "version": "4.17.11",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },

--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -94,12 +94,7 @@ export class ConversationLearner {
      * Define an Callback that will be called after Entity Detection
      * @param target Callback of the form (text: string, memoryManager: ClientMemoryManager) => Promise<void>
      */
-    get EntityDetectionCallback() {
-        return this.clRunner.entityDetectionCallback
-    }
-
-    // TODO: Have to accept `undefined` here to match type of proprety? Should not allow undefined though
-    set EntityDetectionCallback(target: EntityDetectionCallback | undefined) {
+    set EntityDetectionCallback(target: EntityDetectionCallback) {
         this.clRunner.entityDetectionCallback = target
     }
 }

--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -90,10 +90,16 @@ export class ConversationLearner {
         this.clRunner.AddCallback(callback)
     }
 
-    /** Define an Callback that will be called after Entity Detection
+    /**
+     * Define an Callback that will be called after Entity Detection
      * @param target Callback of the form (text: string, memoryManager: ClientMemoryManager) => Promise<void>
      */
-    public EntityDetectionCallback(target: EntityDetectionCallback) {
+    get EntityDetectionCallback() {
+        return this.clRunner.entityDetectionCallback
+    }
+
+    // TODO: Have to accept `undefined` here to match type of proprety? Should not allow undefined though
+    set EntityDetectionCallback(target: EntityDetectionCallback | undefined) {
         this.clRunner.entityDetectionCallback = target
     }
 }


### PR DESCRIPTION
Change EDC to assignment.

Fixes issue Thomas ran into and makes API better explain implementation.
- overwrites
- clear only last function is used
- can only be one