### PR TITLE
feat: add callback for session timeout

### DIFF
--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -5,7 +5,7 @@
 import * as BB from 'botbuilder'
 import * as express from 'express'
 import getRouter from './http/router'
-import { CLRunner, EntityDetectionCallback, OnSessionStartCallback, OnSessionEndCallback, ICallbackInput } from './CLRunner'
+import { CLRunner, EntityDetectionCallback, OnSessionStartCallback, OnSessionEndCallback, ICallbackInput, SessionTimeoutCallback } from './CLRunner'
 import { CLOptions } from './CLOptions'
 import { CLState } from './Memory/CLState'
 import { CLDebug } from './CLDebug'
@@ -96,5 +96,9 @@ export class ConversationLearner {
      */
     set EntityDetectionCallback(target: EntityDetectionCallback) {
         this.clRunner.entityDetectionCallback = target
+    }
+
+    set OnSessionTimeout(sessionTimeoutCallback: SessionTimeoutCallback) {
+        this.clRunner.sessionTimeoutCallback = sessionTimeoutCallback
     }
 }


### PR DESCRIPTION
Fixes ADO#1181

The task said to replace the number with function, but that would mean calling the function every input to see if session should be timed out which seemed very similar to someone creating an end session action and learning to invoke it when entity is set.

I think this combo is still setting inactive time + function allows the function to only be called when the timeout expires.

I'm not sure if this solves the case you wanted it to.
Basically mimics the way we register entity detection callback.