### PR TITLE
fix: recompute action conditions when fetching dialog activities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,9 +499,9 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.213.0.tgz",
-      "integrity": "sha512-ijln5kokjdtCmvsNvoEC9ZFH15QT1xm/P2QrlIrcfMLoHDWvsu2uFKHc9+xdPrYMoLo09SQzdRLIk60riPIZ7w==",
+      "version": "0.214.1",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.214.1.tgz",
+      "integrity": "sha512-lAMQEjlB7Lg3sSQ5Y3NRBjrKVwXBbyac1fI8JS9/jVDG8fp7WezfiQ4/BrRsdFVO5QnbsdV1LZyT0yWdmyoKkA==",
       "requires": {
         "jest-resolve": "^24.8.0"
       },
@@ -544,9 +544,9 @@
       }
     },
     "@conversationlearner/ui": {
-      "version": "0.396.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.396.1.tgz",
-      "integrity": "sha512-/eEM9YZN0bXsmt8HYbIzuQnvZDBZdwh7PeDNZIDQ/gr43TNp9Xn4AmPY6aqXeJjKTbPBBA+Up89hVwGY4mK9Iw=="
+      "version": "0.401.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.401.0.tgz",
+      "integrity": "sha512-QyVUkZqZ8iOs9zU3E3ksHrTWUwyET5UF3oRMZL2OoCfjel4z7kDSS3bkv259ZYyKNE15fVb3/0iYxofrkIjeSw=="
     },
     "@jest/console": {
       "version": "24.3.0",
@@ -4525,8 +4525,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4547,14 +4546,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4569,20 +4566,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4699,8 +4693,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4712,7 +4705,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4727,7 +4719,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4735,14 +4726,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4761,7 +4750,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4849,8 +4837,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4862,7 +4849,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4948,8 +4934,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4985,7 +4970,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5005,7 +4989,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5049,14 +5032,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "author": "Microsoft Conversation Learner Team",
   "license": "MIT",
   "dependencies": {
-    "@conversationlearner/models": "0.213.0",
-    "@conversationlearner/ui": "0.396.1",
+    "@conversationlearner/models": "0.214.1",
+    "@conversationlearner/ui": "0.401.0",
     "@types/supertest": "2.0.4",
     "async-file": "^2.0.2",
     "body-parser": "1.18.3",

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -234,7 +234,7 @@ export const isConditionTrue = (
     }
 }
 
-export const isEnumConditionTrue = (
+const isEnumConditionTrue = (
     condition: CLM.Condition,
     filledEntities: CLM.FilledEntity[]
 ): boolean => {
@@ -249,7 +249,7 @@ export const isEnumConditionTrue = (
     return false
 }
 
-export const isValueConditionTrue = (
+const isValueConditionTrue = (
     condition: CLM.Condition,
     filledEntities: CLM.FilledEntity[],
     entities: CLM.EntityBase[]
@@ -277,7 +277,7 @@ export const isValueConditionTrue = (
         || (condition.condition === CLM.ConditionType.LESS_THEN_OR_EQUAL && numberValue <= condition.value)
 }
 
-export const findNumberFromFilledEntity = (filledEntity: CLM.FilledEntity, isMultivalue: boolean): number | undefined => {
+const findNumberFromFilledEntity = (filledEntity: CLM.FilledEntity, isMultivalue: boolean): number | undefined => {
     if (isMultivalue) {
         return filledEntity.values.length
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -217,4 +217,76 @@ export const isRunningInClUI: (context: BB.TurnContext) => boolean = (context) =
     return context && context.activity && context.activity && context.activity.from && context.activity.from.name === CL_DEVELOPER
 }
 
+export const isConditionTrue = (
+    condition: CLM.Condition,
+    filledEntities: CLM.FilledEntity[],
+    entities: CLM.EntityBase[]
+): boolean => {
+    if (condition.valueId) {
+        return isEnumConditionTrue(condition, filledEntities)
+    }
+    else if (condition.value) {
+        return isValueConditionTrue(condition, filledEntities, entities)
+    }
+    // Unknown condition type, assume false
+    else {
+        return false
+    }
+}
 
+export const isEnumConditionTrue = (
+    condition: CLM.Condition,
+    filledEntities: CLM.FilledEntity[]
+): boolean => {
+    if (condition.valueId) {
+        const filledEntity = filledEntities.find(e => e.entityId === condition.entityId)
+        const enumValueId = filledEntity && filledEntity.values.length > 0 && filledEntity.values[0].enumValueId
+        if (enumValueId === condition.valueId) {
+            return true
+        }
+    }
+
+    return false
+}
+
+export const isValueConditionTrue = (
+    condition: CLM.Condition,
+    filledEntities: CLM.FilledEntity[],
+    entities: CLM.EntityBase[]
+): boolean => {
+    if (condition.value) {
+        const filledEntity = filledEntities.find(e => e.entityId === condition.entityId)
+        const entity = entities.find(e => e.entityId === condition.entityId)
+
+        if (entity && filledEntity) {
+            const numberValue = findNumberFromFilledEntity(filledEntity, entity.isMultivalue)
+            if (numberValue) {
+                return (condition.condition === CLM.ConditionType.EQUAL && numberValue == condition.value)
+                    || (condition.condition === CLM.ConditionType.NOT_EQUAL && numberValue != condition.value)
+                    || (condition.condition === CLM.ConditionType.GREATER_THAN && numberValue > condition.value)
+                    || (condition.condition === CLM.ConditionType.GREATER_THAN_OR_EQUAL && numberValue >= condition.value)
+                    || (condition.condition === CLM.ConditionType.LESS_THAN && numberValue < condition.value)
+                    || (condition.condition === CLM.ConditionType.LESS_THEN_OR_EQUAL && numberValue <= condition.value)
+            }
+        }
+    }
+
+    return false
+}
+
+export const findNumberFromFilledEntity = (filledEntity: CLM.FilledEntity, isMultivalue: boolean): number | undefined => {
+    if (isMultivalue) {
+        return filledEntity.values.length
+    }
+
+    const valueString: string | undefined = filledEntity
+        && filledEntity.values[0]
+        && (filledEntity.values[0].resolution ? true : undefined)
+        && (filledEntity.values[0].resolution as any).value as string
+
+    const value = valueString
+        ? parseInt(valueString, 10)
+        : undefined
+
+    return value
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -254,24 +254,27 @@ export const isValueConditionTrue = (
     filledEntities: CLM.FilledEntity[],
     entities: CLM.EntityBase[]
 ): boolean => {
-    if (condition.value) {
-        const filledEntity = filledEntities.find(e => e.entityId === condition.entityId)
-        const entity = entities.find(e => e.entityId === condition.entityId)
-
-        if (entity && filledEntity) {
-            const numberValue = findNumberFromFilledEntity(filledEntity, entity.isMultivalue)
-            if (numberValue) {
-                return (condition.condition === CLM.ConditionType.EQUAL && numberValue == condition.value)
-                    || (condition.condition === CLM.ConditionType.NOT_EQUAL && numberValue != condition.value)
-                    || (condition.condition === CLM.ConditionType.GREATER_THAN && numberValue > condition.value)
-                    || (condition.condition === CLM.ConditionType.GREATER_THAN_OR_EQUAL && numberValue >= condition.value)
-                    || (condition.condition === CLM.ConditionType.LESS_THAN && numberValue < condition.value)
-                    || (condition.condition === CLM.ConditionType.LESS_THEN_OR_EQUAL && numberValue <= condition.value)
-            }
-        }
+    if (!condition.value) {
+        return false
     }
 
-    return false
+    const filledEntity = filledEntities.find(e => e.entityId === condition.entityId)
+    const entity = entities.find(e => e.entityId === condition.entityId)
+    if (!entity || !filledEntity) {
+        return false
+    }
+
+    const numberValue = findNumberFromFilledEntity(filledEntity, entity.isMultivalue)
+    if (!numberValue) {
+        return false
+    }
+
+    return (condition.condition === CLM.ConditionType.EQUAL && numberValue == condition.value)
+        || (condition.condition === CLM.ConditionType.NOT_EQUAL && numberValue != condition.value)
+        || (condition.condition === CLM.ConditionType.GREATER_THAN && numberValue > condition.value)
+        || (condition.condition === CLM.ConditionType.GREATER_THAN_OR_EQUAL && numberValue >= condition.value)
+        || (condition.condition === CLM.ConditionType.LESS_THAN && numberValue < condition.value)
+        || (condition.condition === CLM.ConditionType.LESS_THEN_OR_EQUAL && numberValue <= condition.value)
 }
 
 export const findNumberFromFilledEntity = (filledEntity: CLM.FilledEntity, isMultivalue: boolean): number | undefined => {


### PR DESCRIPTION
There was bug with conditions not being re-computed when fetching the dialog activities.
This fixes the bug for existing EnumConditions and also adds support for upcoming ValueConditions.

Can see when changing label from "2" (number which means low condition) to "80" number no longer satisfying the low condition and error shown.
![image](http://g.recordit.co/Ribxq4R4V7.gif)
