### PR TITLE
feat: add support for CHANGE_MODEL actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,9 +499,9 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.214.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.214.1.tgz",
-      "integrity": "sha512-lAMQEjlB7Lg3sSQ5Y3NRBjrKVwXBbyac1fI8JS9/jVDG8fp7WezfiQ4/BrRsdFVO5QnbsdV1LZyT0yWdmyoKkA==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.216.0.tgz",
+      "integrity": "sha512-3jbKa6mEFB0KSjJQzezmhMXCuEkqf9ZO+Tr2oY4HbxG8mMewWflk6QFXltEJFf/f0VdNbizeNv/U/8DSQ0hVzw==",
       "requires": {
         "jest-resolve": "^24.8.0"
       },
@@ -544,9 +544,9 @@
       }
     },
     "@conversationlearner/ui": {
-      "version": "0.401.0",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.401.0.tgz",
-      "integrity": "sha512-QyVUkZqZ8iOs9zU3E3ksHrTWUwyET5UF3oRMZL2OoCfjel4z7kDSS3bkv259ZYyKNE15fVb3/0iYxofrkIjeSw=="
+      "version": "0.406.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.406.0.tgz",
+      "integrity": "sha512-eWqmiCd8Qk0Weo3Rk+01a2vTXaWDQk2lxf2NSgSYbHxlQXgZe7E0A14OJ+7fV+xoxNHpXru/4XD7Xu2nF9YeCQ=="
     },
     "@jest/console": {
       "version": "24.3.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "author": "Microsoft Conversation Learner Team",
   "license": "MIT",
   "dependencies": {
-    "@conversationlearner/models": "0.214.1",
-    "@conversationlearner/ui": "0.401.0",
+    "@conversationlearner/models": "0.216.0",
+    "@conversationlearner/ui": "0.406.0",
     "@types/supertest": "2.0.4",
     "async-file": "^2.0.2",
     "body-parser": "1.18.3",

--- a/src/CLRecognizeResult.ts
+++ b/src/CLRecognizeResult.ts
@@ -9,7 +9,7 @@ import { ScoredAction, EntityBase } from '@conversationlearner/models'
 export interface CLRecognizerResult {
     scoredAction: ScoredAction
     clEntities: EntityBase[]
-    memory: CLState
+    state: CLState
     inTeach: boolean
     activity: BB.Activity
 }

--- a/src/CLRecognizeResult.ts
+++ b/src/CLRecognizeResult.ts
@@ -5,10 +5,8 @@
 import { CLState } from './Memory/CLState'
 import * as BB from 'botbuilder'
 import { ScoredAction, EntityBase } from '@conversationlearner/models'
-import { ConversationLearner } from './ConversationLearner'
 
 export interface CLRecognizerResult {
-    model: ConversationLearner
     scoredAction: ScoredAction
     clEntities: EntityBase[]
     memory: CLState

--- a/src/CLRecognizeResult.ts
+++ b/src/CLRecognizeResult.ts
@@ -5,8 +5,10 @@
 import { CLState } from './Memory/CLState'
 import * as BB from 'botbuilder'
 import { ScoredAction, EntityBase } from '@conversationlearner/models'
+import { ConversationLearner } from './ConversationLearner'
 
 export interface CLRecognizerResult {
+    model: ConversationLearner
     scoredAction: ScoredAction
     clEntities: EntityBase[]
     memory: CLState

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -999,7 +999,7 @@ export class CLRunner {
 
                     if (!inTeach) {
                         CLDebug.Log(`Change to Model: ${changeModelAction.modelId} ${changeModelAction.modelName}`, DebugType.Dispatch)
-                        await this.forwardInputToModel(changeModelAction.modelId, clRecognizeResult.state)
+                        await this.forwardInputToModel(changeModelAction.modelId, clRecognizeResult.state, true)
                         // Force response to null to avoid sending message as message will come from next model.
                         actionResult.response = null
                     }

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -1094,7 +1094,7 @@ export class CLRunner {
         }
     }
 
-    public async SendResult(recognizerResult: CLRecognizerResult, uiTrainScorerStep: CLM.UITrainScorerStep | null = null): Promise<void> {
+    public async SendResult(recognizerResult: CLRecognizerResult, uiTrainScorerStep: CLM.UITrainScorerStep | null = null): Promise<IActionResult | undefined> {
         const conversationReference = await recognizerResult.state.BotState.GetConversationReference();
         if (!conversationReference) {
             CLDebug.Error('Missing ConversationReference')
@@ -1111,6 +1111,8 @@ export class CLRunner {
             const context = await this.GetTurnContext(recognizerResult.state)
             await context.sendActivity(actionResult.response)
         }
+
+        return actionResult
     }
 
     private async SendMessage(state: CLState, message: string | Partial<BB.Activity>, incomingActivityId?: string | undefined): Promise<void> {

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -541,7 +541,7 @@ export class CLRunner {
             if (scoredAction.actionType === CLM.ActionTypes.CHANGE_MODEL) {
                 CLDebug.Log(`${CLM.ActionTypes.CHANGE_MODEL} action detected in model ${this.configModelId}.`, DebugType.Dispatch)
                 // TODO: Schema refactor: another hack between scoredAction and Action
-                const changeModelAction = new CLM.DispatchAction(scoredAction as unknown as CLM.ActionBase)
+                const changeModelAction = new CLM.ChangeModelAction(scoredAction as unknown as CLM.ActionBase)
                 CLDebug.Log(`Change to Model: ${changeModelAction.modelId} ${changeModelAction.modelName}`, DebugType.Dispatch)
 
                 // Illegal for model to predict an action that changes to itself
@@ -1018,7 +1018,7 @@ export class CLRunner {
                     break;
                 }
                 case CLM.ActionTypes.CHANGE_MODEL: {
-                    const changeModelAction = new CLM.DispatchAction(clRecognizeResult.scoredAction as any)
+                    const changeModelAction = new CLM.ChangeModelAction(clRecognizeResult.scoredAction as any)
                     actionResult = await this.TakeChangeModelAction(
                         changeModelAction,
                         inTeach,
@@ -1276,7 +1276,7 @@ export class CLRunner {
         }
     }
 
-    public async TakeChangeModelAction(action: CLM.DispatchAction, inTeach: boolean): Promise<IActionResult> {
+    public async TakeChangeModelAction(action: CLM.ChangeModelAction, inTeach: boolean): Promise<IActionResult> {
         try {
             let replayError: CLM.ReplayError | undefined
             let response: Partial<BB.Activity> | string | null = null
@@ -2086,7 +2086,7 @@ export class CLRunner {
                                 const dispatchAction = new CLM.DispatchAction(curAction)
                                 botResponse = await this.TakeDispatchAction(dispatchAction, true)
                             } else if (curAction.actionType === CLM.ActionTypes.CHANGE_MODEL) {
-                                const changeModelAction = new CLM.DispatchAction(curAction)
+                                const changeModelAction = new CLM.ChangeModelAction(curAction)
                                 botResponse = await this.TakeChangeModelAction(changeModelAction, true)
                             }
                             else {

--- a/src/CLRunner.ts
+++ b/src/CLRunner.ts
@@ -553,8 +553,8 @@ export class CLRunner {
                 if (!model) {
                     model = new ConversationLearner(changeModelAction.modelId)
                     model.clRunner.SetAdapter(turnContext.adapter, conversationReference)
-                    state.ConversationModelState.set(model.clRunner.configModelId)
                 }
+                state.ConversationModelState.set(model.clRunner.configModelId)
 
                 const recognizerResult = await model.clRunner.ProcessInput(turnContext)
                 return recognizerResult

--- a/src/CLStrings.ts
+++ b/src/CLStrings.ts
@@ -17,5 +17,6 @@ export enum CLStrings {
     MEMORY_MANAGER_EXPIRED_EXCEPTION = "called after your function has already returned. You must await results within your code rather than use callbacks",
     EXCEPTION_API_CALLBACK = "Exception hit in Bot's API Callback: ",
     MALFORMED_API_CALLBACK = "Malformed API Callback: ",
-    EXCEPTION_ONSESSIONSTART_CALLBACK = "Exception hit in Bot's OnSessionStartCallback"
+    EXCEPTION_ONSESSIONEND_CALLBACK = "Exception hit in Bot's OnSessionEndCallback",
+    EXCEPTION_ONSESSIONSTART_CALLBACK = "Exception hit in Bot's OnSessionStartCallback",
 }

--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -44,7 +44,7 @@ export class ConversationLearner {
     public async recognize(turnContext: BB.TurnContext, force?: boolean): Promise<CLRecognizerResult | null> {
         // tslint:disable-next-line:no-this-assignment
         let activeModel: ConversationLearner = this
-        // If there is more than one model in use for running bot need to check which model is active for conversation
+        // If there is more than one model in use for running bot we need to check which model is active for conversation
         // This check avoids doing work for normal singe model model bots
         if (ConversationLearner.models.length > 1) {
             const context = CLState.GetFromContext(turnContext)
@@ -88,7 +88,7 @@ export class ConversationLearner {
     }
 
     public async SendResult(result: CLRecognizerResult): Promise<void> {
-        await this.clRunner.SendIntent(result)
+        await this.clRunner.SendResult(result)
     }
 
     /** Returns true is bot is running in the Training UI

--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -43,7 +43,7 @@ export class ConversationLearner {
         const result = await this.clRunner.recognize(turnContext, force)
 
         // If no new active model was specified, set the model to the current model
-        if (result && typeof result.model == undefined) {
+        if (result && result.model == undefined) {
             result.model = this
         }
 

--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -40,7 +40,14 @@ export class ConversationLearner {
     }
 
     public async recognize(turnContext: BB.TurnContext, force?: boolean): Promise<CLRecognizerResult | null> {
-        return await this.clRunner.recognize(turnContext, force)
+        const result = await this.clRunner.recognize(turnContext, force)
+
+        // If no new active model was specified, set the model to the current model
+        if (result && typeof result.model == undefined) {
+            result.model = this
+        }
+
+        return result
     }
 
     /**

--- a/src/Memory/CLState.ts
+++ b/src/Memory/CLState.ts
@@ -31,18 +31,21 @@ export class CLState {
     BotState: BotState
     EntityState: EntityState
     MessageState: MessageState
+    ConversationModelState: MessageState
     BrowserSlotState: BrowserSlotState
 
     private constructor(
         botState: BotState,
         entityState: EntityState,
         messageState: MessageState,
+        conversationModelState: MessageState,
         browserSlotState: BrowserSlotState,
-        turnContext?: BB.TurnContext) {
-
+        turnContext?: BB.TurnContext,
+    ) {
         this.BotState = botState
         this.EntityState = entityState
         this.MessageState = messageState
+        this.ConversationModelState = conversationModelState
         this.BrowserSlotState = browserSlotState
 
         this.turnContext = turnContext
@@ -58,7 +61,7 @@ export class CLState {
         CLState.bbStorage = storage
     }
 
-    public static Get(key: string, modelId: string = ''): CLState {
+    public static Get(key: string, modelId: string = '', turnContext?: BB.TurnContext): CLState {
         const storage = new CLStorage(CLState.bbStorage)
 
         // Used for state shared through lifetime of conversation (conversationId)
@@ -69,9 +72,17 @@ export class CLState {
         const botState = new BotState(storage, (datakey) => `${modelUniqueKeyPrefix}_BOTSTATE_${datakey}`)
         const entityState = new EntityState(storage, () => `${modelUniqueKeyPrefix}_ENTITYSTATE`)
         const messageState = new MessageState(storage, () => `${keyPrefix}_MESSAGE_MUTEX`)
+        const conversationModelState = new MessageState(storage, () => `${keyPrefix}_CONVERSATION_MODEL`)
         const browserSlotState = new BrowserSlotState(storage, () => `BROWSER_SLOTS`)
 
-        return new CLState(botState, entityState, messageState, browserSlotState)
+        return new CLState(
+            botState,
+            entityState,
+            messageState,
+            conversationModelState,
+            browserSlotState,
+            turnContext,
+        )
     }
 
     public static GetFromContext(turnContext: BB.TurnContext, modelId: string = ''): CLState {
@@ -97,7 +108,7 @@ export class CLState {
             keyPrefix = conversationReference.conversation.id
         }
 
-        return CLState.Get(keyPrefix, !isRunningInUI ? modelId : undefined)
+        return CLState.Get(keyPrefix, modelId, turnContext)
     }
 
     public async SetAppAsync(app: CLM.AppBase | null): Promise<void> {

--- a/src/Memory/CLState.ts
+++ b/src/Memory/CLState.ts
@@ -108,7 +108,7 @@ export class CLState {
             keyPrefix = conversationReference.conversation.id
         }
 
-        return CLState.Get(keyPrefix, modelId, turnContext)
+        return CLState.Get(keyPrefix, !isRunningInUI ? modelId : undefined, turnContext)
     }
 
     public async SetAppAsync(app: CLM.AppBase | null): Promise<void> {

--- a/src/Memory/InputQueue.ts
+++ b/src/Memory/InputQueue.ts
@@ -18,10 +18,9 @@ export class InputQueue {
 
     private static messageQueue: QueuedInput[] = [];
 
-    public static async AddInput(inProcessMessageState: InProcessMessageState, activity: BB.Activity, conversationReference: Partial<BB.ConversationReference>, callback: Function): Promise<any> {
-
+    public static async AddInput(inProcessMessageState: InProcessMessageState, activity: BB.Activity, conversationReference: Partial<BB.ConversationReference>, callback: Function): Promise<void> {
         if (!activity.id) {
-            return null;
+            return
         }
 
         // Add to queue

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -1057,12 +1057,12 @@ export const getRouter = (client: CLClient, options: ICLClientOptions): express.
             const intent = {
                 scoredAction: scoredAction,
                 clEntities: uiTrainScorerStep.entities,
-                memory: state,
+                state: state,
                 inTeach: true
             } as CLRecognizerResult
 
             const clRunner = CLRunner.GetRunnerForUI(appId);
-            const actionResult = await clRunner.SendIntent(intent, uiTrainScorerStep)
+            const actionResult = await clRunner.SendResult(intent, uiTrainScorerStep)
 
             // Set logicResult on scorer step
             if (actionResult) {
@@ -1225,7 +1225,7 @@ export const getRouter = (client: CLClient, options: ICLClientOptions): express.
                     }
 
                     // Get session Id
-                    const sessionId = await result.memory.BotState.GetSessionIdAsync()
+                    const sessionId = await result.state.BotState.GetSessionIdAsync()
                     if (!sessionId) {
                         res.send(null)
                         return
@@ -1241,7 +1241,7 @@ export const getRouter = (client: CLClient, options: ICLClientOptions): express.
                     // Server enforces max number of non-terminal actions, so no endless loop here
                     while (!bestAction.isTerminal) {
                         curHashIndex = curHashIndex + 1
-                        bestAction = await clRunner.Score(appId, sessionId, result.memory, '', [], result.clEntities, false, true)
+                        bestAction = await clRunner.Score(appId, sessionId, result.state, '', [], result.clEntities, false, true)
                         result.scoredAction = bestAction
 
                         // Include apiResults when taking action so result will be the same when testing


### PR DESCRIPTION
- Ensure all instantiated models are put in model cache by making it part of construction instead of explicit addition.
- Add `ConversationModelState` to store which model is active for conversation.
- Consolidate placeholder card renderings for actions that have no visual effect on dialog.
- Fix what looks to be bug with not storing `turnContext`
