### PR TITLE
fix: make callback assignment consistent

### DIFF
--- a/src/ConversationLearner.ts
+++ b/src/ConversationLearner.ts
@@ -74,7 +74,7 @@ export class ConversationLearner {
      * Provide an callback that will be invoked whenever a Session is started
      * @param target Callback of the form (context: BB.TurnContext, memoryManager: ClientMemoryManager) => Promise<void>
      */
-    public OnSessionStartCallback(target: OnSessionStartCallback) {
+    set OnSessionStartCallback(target: OnSessionStartCallback) {
         this.clRunner.onSessionStartCallback = target
     }
 
@@ -83,7 +83,7 @@ export class ConversationLearner {
      * can end because of a timeout or the selection of an EndSession activity
      * @param target Callback of the form (context: BB.TurnContext, memoryManager: ClientMemoryManager, sessionEndState: CLM.SessionEndState, data: string | undefined) => Promise<string[] | undefined>
      */
-    public OnSessionEndCallback(target: OnSessionEndCallback) {
+    set OnSessionEndCallback(target: OnSessionEndCallback) {
         this.clRunner.onSessionEndCallback = target
     }
 


### PR DESCRIPTION
Lars had mentioned breaking changes in chat and reminded me to do this.

EntityDetectionCallback was changed to be assignment to better express how the code works but I should have changed them all. This PR should make all the single model specific callbacks assignment.
The code callbacks for actions are still left as method since you can have many.

Do you see any thing I missed?  Would rather have one breaking change than two.