### PR TITLE
fix: bug 2417 multi-conversation message queuing

### DIFF
--- a/src/CLClient.ts
+++ b/src/CLClient.ts
@@ -353,15 +353,6 @@ export class CLClient {
         return this.send('PUT', this.MakeSessionURL(apiPath), scorerInput)
     }
 
-    /**
-     * Updates the score if the SDK decides to force the action to something other than the highest scoring one
-     * Only valid field to change is "forceActionId"
-     */
-    public SessionScoreFeedback(appId: string, teachId: string, scorerResponse: Partial<CLM.LogScorerStep>): Promise<CLM.TeachResponse> {
-        let apiPath = `app/${appId}/session/${teachId}/scorer`
-        return this.send('POST', this.MakeURL(apiPath), scorerResponse)
-    }
-
     public SessionLogicResult(appId: string, sessionId: string, actionId: string, actionResult: IActionResult) {
         let apiPath = `app/${appId}/session/${sessionId}/scorerSteps/action/${actionId}/logicResult`
         return this.send('PUT', this.MakeSessionURL(apiPath), { logicResult: actionResult.logicResult })

--- a/src/Memory/BotState.ts
+++ b/src/Memory/BotState.ts
@@ -247,7 +247,7 @@ export class BotState {
     // ------------------------------------------------
     public async getUIMode(): Promise<UIMode> {
         const uiMode = await this.GetStateAsync<UIMode>(BotStateType.UI_MODE)
-        return uiMode
+        return uiMode || UIMode.NONE
     }
 
     public async SetUIMode(uiMode: UIMode): Promise<void> {

--- a/src/Memory/CLState.ts
+++ b/src/Memory/CLState.ts
@@ -114,7 +114,6 @@ export class CLState {
     public async SetAppAsync(app: CLM.AppBase | null): Promise<void> {
         const curApp = await this.BotState.GetApp();
         await this.BotState.SetAppAsync(app)
-        await this.MessageState.remove()
 
         if (!app || !curApp || curApp.appId !== app.appId) {
             await this.EntityState.ClearAsync()

--- a/src/Memory/InputQueue.test.ts
+++ b/src/Memory/InputQueue.test.ts
@@ -66,7 +66,8 @@ describe('InputQueue', () => {
 
         // Need longer jest timeout for this test
         const processTime = (mutexDelay + processDelay) * inputs.length
-        jest.setTimeout(2 * processTime)
+        // tslint:disable-next-line no-string-based-set-timeout  - tslint bug
+        jest.setTimeout(processTime * 2)
 
         for (let input of inputs) {
             addInput(clState, input, conversationId)
@@ -94,7 +95,8 @@ describe('InputQueue', () => {
 
         // Need longer jest timeout for this test
         const processTime = (mutexDelay + processDelay) * (inputs1.length + inputs2.length)
-        jest.setTimeout(2 * processTime)
+        // tslint:disable-next-line no-string-based-set-timeout - tslint bug
+        jest.setTimeout(processTime * 2)
 
         for (let i = 0; i < inputs1.length; i = i + 1) {
             addInput(clState1, inputs1[i], conversation1Id)

--- a/src/Memory/InputQueue.test.ts
+++ b/src/Memory/InputQueue.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as util from 'util'
+import * as BB from 'botbuilder'
+import * as CLM from '@conversationlearner/models'
+import { CLState } from './CLState'
+import { InputQueue } from '../Memory/InputQueue'
+
+// InputQueue requires tiny delay between inputs or InputQueue mutex won't fishing setting
+const mutexDelay = 50
+// Delay to simulate CLRunner ProcessInput
+const processDelay = 1000
+const userAccount: BB.ChannelAccount = { id: "user", name: "user", role: BB.RoleTypes.User, aadObjectId: '' }
+const botAccount: BB.ChannelAccount = { id: "bot", name: "bot", role: BB.RoleTypes.Bot, aadObjectId: '' }
+let responses: { [key: string]: string[] } = {}
+
+// Use any as return type as is not a full Activity, just bare minimum for test
+function makeActivity(message: string, conversationId: string): any {
+    return {
+        id: CLM.ModelUtils.generateGUID(),
+        conversation: { id: conversationId },
+        from: botAccount,
+        recipient: userAccount,
+        type: 'message',
+        text: message,
+    }
+}
+
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Simulate AddInput function in CLRunner
+async function addInput(state: CLState, message: string, conversationId: string) {
+    const activity = makeActivity(message, conversationId)
+    let addInputPromise = util.promisify(InputQueue.AddInput)
+    let isReady = await addInputPromise(state.MessageState, activity)
+
+    if (isReady) {
+        // Handle input with a delay to simulate CLRunner ProcessInput
+        await sleep(processDelay)
+
+        if (!responses[conversationId]) {
+            responses[conversationId] = []
+        }
+
+        responses[conversationId].push(activity.text)
+        InputQueue.MessageHandled(state.MessageState, conversationId, activity)
+    }
+}
+
+describe('InputQueue', () => {
+
+    beforeEach(() => {
+        CLState.Init()
+        responses = {}
+    })
+
+    it('should handle all messages in a single queue', async () => {
+
+        const clState = CLState.Get("InputQueueTest", undefined)
+        const conversationId = CLM.ModelUtils.generateGUID()
+        const inputs = ["A", "B", "C", "D", "E"]
+
+        // Need longer jest timeout for this test
+        const processTime = (mutexDelay + processDelay) * inputs.length
+        jest.setTimeout(2 * processTime)
+
+        for (let input of inputs) {
+            addInput(clState, input, conversationId)
+            await sleep(mutexDelay)
+        }
+
+        // Give messages time to process
+        await sleep(processTime)
+
+        // Check that they were handled
+        const messages = responses[conversationId]
+        console.log(messages.join(" "))
+        expect(messages.length).toBe(inputs.length)
+        messages.forEach((m, i) => expect(m).toBe(inputs[i]))
+    })
+
+    it('should handle multiple conversations', async () => {
+
+        const clState1 = CLState.Get("InputQueueTest1", undefined)
+        const clState2 = CLState.Get("InputQueueTest2", undefined)
+        const conversation1Id = CLM.ModelUtils.generateGUID()
+        const conversation2Id = CLM.ModelUtils.generateGUID()
+        const inputs1 = ["A", "B", "C", "D", "E"]
+        const inputs2 = ["1", "2", "3", "4", "5"]
+
+        // Need longer jest timeout for this test
+        const processTime = (mutexDelay + processDelay) * (inputs1.length + inputs2.length)
+        jest.setTimeout(2 * processTime)
+
+        for (let i = 0; i < inputs1.length; i = i + 1) {
+            addInput(clState1, inputs1[i], conversation1Id)
+            await sleep(mutexDelay)
+            addInput(clState2, inputs2[i], conversation2Id)
+            await sleep(mutexDelay)
+        }
+
+        // Give messages time to process
+        await sleep(processTime)
+
+        // Check that they were handled
+        const messages1 = responses[conversation1Id]
+        expect(messages1.length).toBe(inputs1.length)
+        messages1.forEach((m, i) => expect(m).toBe(inputs1[i]))
+
+        const messages2 = responses[conversation2Id]
+        expect(messages2.length).toBe(inputs2.length)
+        messages2.forEach((m, i) => expect(m).toBe(inputs2[i]))
+    })
+})


### PR DESCRIPTION
When we refactored the memory we switched to using a conversationId scoped mutex but were still using a shared queue which caused multi-conversations to run into issues.   Fixed the bug and also took opportunity to clean it up a bit and add tests.  

Note queue is still in-memory so won't work for multi-host bots.  See ADO 2412